### PR TITLE
ci: add derivative warning action

### DIFF
--- a/.github/workflows/create_db_derivatives.yaml
+++ b/.github/workflows/create_db_derivatives.yaml
@@ -1,4 +1,4 @@
-name: Create and commit category, images and extended database files
+name: Create derivative databases
 
 on:
   push:

--- a/.github/workflows/post_derivative_warning.yml
+++ b/.github/workflows/post_derivative_warning.yml
@@ -1,0 +1,31 @@
+name: Post derivative warning
+
+on: 
+  pull_request:
+    paths:
+      - "*.csv"
+      - "!plane-alert-db.csv"
+      - "!plane-alert-pia.csv"
+      - "!plane-alert-twitter-blocked.csv"
+      - "!plane-alert-ukraine.csv"
+
+jobs:
+  postDerivativeWarning:
+    runs-on: ubuntu-latest
+    name: Post a warning pull request comment when a user changes a derivative file
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Retrieve warning message from READ_BEFORE_MAKING_CHANGES.md
+        run: |
+          echo "WARNING_MSG<<EOF" >> $GITHUB_ENV
+          echo "$(cat READ_BEFORE_MAKING_CHANGES.md | tail -n +3)" >> $GITHUB_ENV 
+          echo "EOF" >> $GITHUB_ENV
+
+      - name: Post derivative warning
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: |
+            ${{ env.WARNING_MSG }}  
+          comment_tag: execution

--- a/READ_BEFORE_MAKING_CHANGES.md
+++ b/READ_BEFORE_MAKING_CHANGES.md
@@ -3,8 +3,8 @@
 Please only suggest/make any changes to the following files:
 
 - [plane-alert-db.csv](plane-alert-db.csv): This is the main database file. All non-image changes should be done here.
-- [plane-alert-twitter-blocked.csv](plane-alert-twitter-blocked.txt): This source file contains planes that will cause your Twitter account to be banned. Please use it with care.
 - [plane-alert-pia.csv](plane-alert-pia.csv): This list contains PIA planes.
+- [plane-alert-twitter-blocked.csv](plane-alert-twitter-blocked.txt): This source file contains planes that will cause your Twitter account to be banned. Please use it with care.
 - [plane-alert-ukraine.csv](plane-alert-ukraine.csv): This list contains Ukrainian planes.
 - [plane_images.txt](plane_images.txt): You can add plane images in this source file.
 


### PR DESCRIPTION
This commit adds a new github action that comments a warning to pull requests in which users try to change derivative databases.