### PR TITLE
AE54D5, 3F9A92, 3F4BA9, AE119B, 43C8EA, & 3F6F02 Photos; Correct 3D4365 Plane Type

### DIFF
--- a/plane-alert-db.csv
+++ b/plane-alert-db.csv
@@ -4201,8 +4201,8 @@ A8F778,N677TX,Private,DHC-2 Beaver U-6A,DHC2,Civ,Radial Engine,Highwing,I Am Old
 400EFA,G-EEEK,Private,Extra EA-300,E300,Civ,Do A Barrel Roll,High G,Aerobatics,Joe Cool,https://w.wiki/4nF6
 406C56,G-WVEN,Private,Extra EA-300,E300,Civ,Do A Barrel Roll,High G,Aerobatics,Joe Cool,https://w.wiki/4nF6
 407821,G-EZMT,Private,Extra EA-300,E300,Civ,Do A Barrel Roll,High G,Aerobatics,Joe Cool,https://w.wiki/4nF6
-3D4365,EC-KFV,Private,Extra EA-300,E300,Civ,Do A Barrel Roll,High G,Aerobatics,Joe Cool,https://w.wiki/4nF6
-A18EA9,N2PU,Private,Extra EA-300,E300,Civ,Do A Barrel Roll,High G,Aerobatics,Joe Cool,https://w.wiki/4nF6
+3D4365,EC-KFV,Private,Extra EA-200,E200,Civ,Do A Barrel Roll,High G,Aerobatics,Joe Cool,https://w.wiki/4nF6
+A18EA9,N2PU,Private,Extra EA-300,E300,Civ,Do A Barrel Roll,High G,Aerobatics,Joe Cool,https://w.wiki/6Y2P
 40436D,G-XXHP,Private,Extra EA-300L,E300,Civ,Aerobatics,Do A Barrel Roll,Bicycle Made For Two,Joe Cool,https://w.wiki/4nF6
 49D104,OK-ELC,Private,Extra EA-300L,E300,Civ,Aerobatics,Do A Barrel Roll,Bicycle Made For Two,Joe Cool,https://w.wiki/4nF6
 3D427D,D-EXKV,Private,Extra EA-300L,E300,Civ,Aerobatics,Do A Barrel Roll,Bicycle Made For Two,Joe Cool,https://w.wiki/4nF6

--- a/plane_images.txt
+++ b/plane_images.txt
@@ -2749,7 +2749,7 @@ A00E20,,,,
 3F66B0,,,,
 3F6682,,,,
 3F64F6,,,,
-3F4BA9,,,,
+3F4BA9,https://cdn.jetphotos.com/full/5/30860_1553755979.jpg,https://cdn.jetphotos.com/full/6/57631_1618048319.jpg,https://cdn.jetphotos.com/full/5/72637_1602632743.jpg,https://cdn.jetphotos.com/full/6/43940_1668615502.jpg
 3F4368,,,,
 3EA653,,,,
 3EA1CC,,,,

--- a/plane_images.txt
+++ b/plane_images.txt
@@ -11870,7 +11870,7 @@ AE5C95,https://cdn.jetphotos.com/full/5/10089_1494589280.jpg,,,
 AE596F,https://cdn.jetphotos.com/full/6/60290_1569161994.jpg,https://cdn.jetphotos.com/full/5/82691_1543772943.jpg,https://cdn.jetphotos.com/full/5/62216_1537481438.jpg,
 AE596E,https://cdn.jetphotos.com/full/5/61594_1611876314.jpg,https://cdn.jetphotos.com/full/6/92840_1567577532.jpg,https://cdn.jetphotos.com/full/5/17112_1566388566.jpg,
 AE596D,https://cdn.jetphotos.com/full/5/28922_1638685661.jpg,https://cdn.jetphotos.com/full/5/52669_1519236539.jpg,,
-AE54D5,,,,
+AE54D5,https://cdn.jetphotos.com/full/5/94338_1495893995.jpg,https://cdn.jetphotos.com/full/6/92947_1632743633.jpg,https://cdn.jetphotos.com/full/6/99396_1512950036.jpg,https://cdn.jetphotos.com/full/5/73847_1529603581.jpg
 AE54D2,,,,
 AE54D1,,,,
 AE54CA,,,,

--- a/plane_images.txt
+++ b/plane_images.txt
@@ -12551,7 +12551,7 @@ C06AC2,https://cdn.jetphotos.com/full/5/80914_1619223739.jpg,https://cdn.jetphot
 43C1E6,https://cdn.jetphotos.com/full/5/34783_1414496541.jpg,https://cdn.jetphotos.com/full/5/73429_1399828092.jpg,https://cdn.jetphotos.com/full/4/14426_1392246596.jpg,
 4009E6,https://cdn.jetphotos.com/full/5/96425_1420280471.jpg,https://cdn.jetphotos.com/full/6/14890_1420280598.jpg,https://cdn.jetphotos.com/full/5/18642_1416867204.jpg,
 43C8F5,,,,
-43C8EA,,,,
+43C8EA,https://cdn.airplane-pictures.net/images/uploaded-images/2020/11/5/1352996.jpg,https://live.staticflickr.com/4912/45733838492_b4268a986c_b.jpg,https://media.abpic.co.uk/pictures/full_size_0501/1761457-large.jpg,https://media.abpic.co.uk/pictures/full_size_0410/1617934-large.jpg
 43C8E3,https://cdn.jetphotos.com/full/5/43199_1608421977.jpg,https://cdn.jetphotos.com/full/6/73489_1590262786.jpg,https://cdn.jetphotos.com/full/5/92030_1555010045.jpg,
 43C8E7,,,,
 39B415,https://cdn.jetphotos.com/full/5/37627_1619109267.jpg,https://cdn.jetphotos.com/full/5/49356_1608148080.jpg,https://cdn.jetphotos.com/full/5/33202_1605311112.jpg,

--- a/plane_images.txt
+++ b/plane_images.txt
@@ -2762,7 +2762,7 @@ A00E20,,,,
 3F49E6,,,,
 3E9FD2,,,,
 3F6C26,https://cdn.jetphotos.com/full/5/38832_1636793122.jpg,https://cdn.jetphotos.com/full/6/94922_1640103891.jpg,https://cdn.jetphotos.com/full/5/77132_1666718047.jpg,https://cdn.jetphotos.com/full/6/37063_1666980761.jpg
-3F6F02,,,,
+3F6F02,https://cdn.jetphotos.com/full/5/94531_1505130312.jpg,https://cdn.jetphotos.com/full/5/18186_1526495308.jpg,https://cdn.jetphotos.com/full/5/94415_1651571859.jpg,https://cdn.jetphotos.com/full/6/96811_1669304893.jpg
 3E865F,https://cdn.jetphotos.com/full/6/67782_1581075783.jpg,https://cdn.jetphotos.com/full/5/51597_1579120133.jpg,https://cdn.jetphotos.com/full/6/38385_1563975274.jpg,https://cdn.jetphotos.com/full/6/39724_1641667597.jpg
 3F8019,,,,
 3F4D0C,,,,

--- a/plane_images.txt
+++ b/plane_images.txt
@@ -1993,7 +1993,7 @@ AC42FA,https://cdn.jetphotos.com/full/4/74439_1316285107.jpg,https://cdn.jetphot
 405B74,https://cdn.jetphotos.com/full/6/48911_1466101526.jpg,https://cdn.jetphotos.com/full/4/35454_1331726473.jpg,https://cdn.jetphotos.com/full/2/53605_1233561666.jpg,
 3CCE71,https://cdn.jetphotos.com/full/6/29493_1639156132.jpg,https://cdn.jetphotos.com/full/6/37035_1638617544.jpg,https://cdn.jetphotos.com/full/6/25463_1634763083.jpg,
 43E7CE,https://cdn.jetphotos.com/full/6/69994_1630954021.jpg,https://cdn.jetphotos.com/full/5/48856_1629146229.jpg,https://cdn.jetphotos.com/full/6/43405_1627762291.jpg,
-3F9A92,,,,
+3F9A92,https://cdn.jetphotos.com/full/6/38416_1570568125.jpg,https://cdn.jetphotos.com/full/6/66005_1566657800.jpg,https://cdn.jetphotos.com/full/6/52784_1596641111.jpg,https://cdn.jetphotos.com/full/6/16436_1633011765.jpg
 3F6EEA,https://cdn.jetphotos.com/full/5/42241_1631715975.jpg,https://cdn.jetphotos.com/full/5/93530_1497164107.jpg,https://cdn.jetphotos.com/full/6/47690_1497049677.jpg,
 3F9C84,https://cdn.jetphotos.com/full/6/70510_1613061242.jpg,,,
 3F9AE8,https://cdn.jetphotos.com/full/6/24667_1558857611.jpg,,,

--- a/plane_images.txt
+++ b/plane_images.txt
@@ -11460,7 +11460,7 @@ AE1233,,,,
 AE1232,,,,
 AE119D,https://cdn.jetphotos.com/full/6/45869_1467831978.jpg,https://cdn.jetphotos.com/full/1/69451_1121299916.jpg,https://cdn.jetphotos.com/full/6/90579_1443716702.jpg,https://cdn.jetphotos.com/full/1/79174_1273321843.jpg
 AE119C,https://live.staticflickr.com/65535/50150171778_933fa9cf1e_k.jpg,https://cdn.jetphotos.com/full/5/50556_1617982729.jpg,https://cdn.jetphotos.com/full/6/45406_1612259142.jpg,
-AE119B,,,,
+AE119B,https://cdn.jetphotos.com/full/5/94608_1651965938.jpg,https://cdn.jetphotos.com/full/5/29050_1431972896.jpg,https://cdn.jetphotos.com/full/6/15826_1625364141.jpg,https://cdn.jetphotos.com/full/2/86784_1156053949.jpg
 AE119A,,,,
 AE1199,,,,
 AE1198,,,,


### PR DESCRIPTION
## Describe your changes
Add photos for:
- AE54D5
- 3F9A92
- 3F4BA9
- AE119B
- 43C8EA
- 3F6F02
Correct Plane Type for 3D4365
- E200 instead of E300

<!-- Briefly describe the changes you made. 

NEW FEATURE: Please explain why the feature is needed.
BUG FIX: Please explain the bug and how you fixed this bug.
PLANE INFO: Please add the sources used to aid the review process.
-->

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] While waiting for someone to review your request, please help review [another open pull request](https://github.com/sdr-enthusiasts/plane-alert-db/pulls) to support the maintainers.
