### PR TITLE
Remove line terminator from write to plane_images.txt

### DIFF
--- a/scripts/create_db_derivatives.py
+++ b/scripts/create_db_derivatives.py
@@ -119,7 +119,6 @@ if __name__ == "__main__":
             index=False,
             header=True,
             encoding="utf8",
-            lineterminator="\n",
         )
         logging.info("New ICAOs successfully saved in 'plane_images.txt' file.")
     else:


### PR DESCRIPTION
## Describe your changes
Line terminator is causing Github to flag every row as edited in `plane_images.txt`. Works in my repo without it.
<!-- Briefly describe the changes you made. 

NEW FEATURE: Please explain why the feature is needed.
BUG FIX: Please explain the bug and how you fixed this bug.
PLANE INFO: Please add the sources used to aid the review process.
-->

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] While waiting for someone to review your request, please help review [another open pull request](https://github.com/sdr-enthusiasts/plane-alert-db/pulls) to support the maintainers.
