### PR TITLE
Update labeler.yml for recent plane_images extension change

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,4 +2,4 @@ documentation: readme.md
 images: plane_images.csv
 ukraine: plane-alert-ukraine.csv
 twitter: plane-alert-twitter.csv
-planes: "*.csv"
+planes: -any: ['*.csv', '!plane_images.csv']


### PR DESCRIPTION
## Describe your changes
Update labeler to not incorrectly apply the planes tag to a image only PR.
<!-- Briefly describe the changes you made. 

NEW FEATURE: Please explain why the feature is needed.
BUG FIX: Please explain the bug and how you fixed this bug.
PLANE INFO: Please add the sources used to aid the review process.
-->

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] While waiting for someone to review your request, please help review [another open pull request](https://github.com/sdr-enthusiasts/plane-alert-db/pulls) to support the maintainers.
