### PR TITLE
Correct yml spacing

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,4 +2,5 @@ documentation: readme.md
 images: plane_images.csv
 ukraine: plane-alert-ukraine.csv
 twitter: plane-alert-twitter.csv
-planes: -any: ['*.csv', '!plane_images.csv']
+planes:
+- any: ['*.csv', '!plane_images.csv']


### PR DESCRIPTION
## Describe your changes
Fix #225 the broke the labeler. Missing space between hypen and any. `-any` should be `- any`.
<!-- Briefly describe the changes you made. 

NEW FEATURE: Please explain why the feature is needed.
BUG FIX: Please explain the bug and how you fixed this bug.
PLANE INFO: Please add the sources used to aid the review process.
-->

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] While waiting for someone to review your request, please help review [another open pull request](https://github.com/sdr-enthusiasts/plane-alert-db/pulls) to support the maintainers.
