### PR TITLE
N540PA Remove photo of 1984 PanAM 747.

### DIFF
--- a/plane_images.csv
+++ b/plane_images.csv
@@ -3743,7 +3743,7 @@ A18729,https://cdn.jetphotos.com/full/5/46532_1605029680.jpg,https://cdn.jetphot
 A0FE19,https://cdn.jetphotos.com/full/6/68956_1645111429.jpg,https://cdn.jetphotos.com/full/6/60700_1620946652.jpg,https://cdn.jetphotos.com/full/6/90270_1620926085.jpg,
 A69910,https://upload.wikimedia.org/wikipedia/commons/2/27/Phoenix_Air_Learjet_landing_at_North_Island_NAS_%283767183347%29.jpg,https://live.staticflickr.com/6157/6177022542_7057e72e1e_b.jpg,,
 AAE0D0,https://cdn.jetphotos.com/full/6/81326_1622212709.jpg,,,
-A6D932,https://cdn.jetphotos.com/full/6/55906_1591085054.jpg,https://cdn.jetphotos.com/full/6/13983_1588029452.jpg,https://cdn.jetphotos.com/full/5/16118_1565490055.jpg,
+A6D932,https://cdn.jetphotos.com/full/6/55906_1591085054.jpg,https://cdn.jetphotos.com/full/6/13983_1588029452.jpg,,
 A6FAA1,https://cdn.jetphotos.com/full/1/70337_1154884923.jpg,https://cdn.jetphotos.com/full/1/26745_1101505901.jpg,,
 A745E8,https://www.airport-data.com/images/aircraft/000/047/047689.jpg,,,
 A6E80E,https://cdn.jetphotos.com/full/1/20668_1192897504.jpg,,,


### PR DESCRIPTION
This callsign is now a LearJet but there is a nice photo of the 747 it used to be the database as well; this change removes the 747 photo.

https://airwaves.social/@overvabot/110673241144072316 <- One of these things is not like the other.

## Describe your changes

This removes 1 of the 3 photos of the above callsign from the photos csv.  I think the link above to the mastodon toot illustrates why.  There is a photo from 1984 showing the 747 this plane used to be, however the present registration is a LearJet.  This removes the old photo.

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/sdr-enthusiasts/plane-alert-db/pulls) to support the maintainers. (Sadly there are no other pull requests at the moment!)
