### PR TITLE
added USAF TH-1s: AE2936-39, AE20BC-F

### DIFF
--- a/plane-alert-db.csv
+++ b/plane-alert-db.csv
@@ -13050,3 +13050,4 @@ AE4BEA,74-22428,USAF,Bell TH-1H Iroquois,UH1,Mil,Huey,Get To The Choppa,To Fly F
 AE4BEB,72-21483,USAF,Bell TH-1H Iroquois,UH1,Mil,Huey,Get To The Choppa,To Fly Fight And Win,USAF,https://youtu.be/M4nFSdNNFQw
 AE4BEC,74-22463,USAF,Bell TH-1H Iroquois,UH1,Mil,Huey,Get To The Choppa,To Fly Fight And Win,USAF,https://youtu.be/M4nFSdNNFQw
 AE1849,71-20167,USAF,Bell TH-1H Iroquois,UH1,Mil,Huey,Get To The Choppa,To Fly Fight And Win,USAF,https://youtu.be/M4nFSdNNFQw
+AE4EB7,168433,United States Navy,Boeing P-8A Poseidon,P8,P8,Mil,One Ping Only Vasily,Maritime Patrol,Eye In The Sky,Oxcart,https://w.wiki/3qBW

--- a/plane-alert-db.csv
+++ b/plane-alert-db.csv
@@ -13050,4 +13050,4 @@ AE4BEA,74-22428,USAF,Bell TH-1H Iroquois,UH1,Mil,Huey,Get To The Choppa,To Fly F
 AE4BEB,72-21483,USAF,Bell TH-1H Iroquois,UH1,Mil,Huey,Get To The Choppa,To Fly Fight And Win,USAF,https://youtu.be/M4nFSdNNFQw
 AE4BEC,74-22463,USAF,Bell TH-1H Iroquois,UH1,Mil,Huey,Get To The Choppa,To Fly Fight And Win,USAF,https://youtu.be/M4nFSdNNFQw
 AE1849,71-20167,USAF,Bell TH-1H Iroquois,UH1,Mil,Huey,Get To The Choppa,To Fly Fight And Win,USAF,https://youtu.be/M4nFSdNNFQw
-AE4EB7,168433,United States Navy,Boeing P-8A Poseidon,P8,P8,Mil,One Ping Only Vasily,Maritime Patrol,Eye In The Sky,Oxcart,https://w.wiki/3qBW
+AE4EB7,168433,United States Navy,Boeing P-8A Poseidon,P8,Mil,One Ping Only Vasily,Maritime Patrol,Eye In The Sky,Oxcart,https://w.wiki/3qBW

--- a/plane-alert-db.csv
+++ b/plane-alert-db.csv
@@ -13030,10 +13030,18 @@ AE60EC,160490,United States Marine Corps,Beech T-34C Turbo Mentor,T34T,Mil,Train
 3EAD63,54+39,German Air Force,Airbus Military A400M Atlas C1,A400,Mil,Luftbrucke,Cargo,Luftwaffe,GAF,https://www.bundeswehr.de/de/organisation/luftwaffe
 7500C5,M48-02,Royal Malaysian Air Force,Bombardier Global 6000,GLEX,Gov,Malaysia,Must Be Nice,Government,Governments,https://w.wiki/6kH5
 0AC8BD,FAC3104,Colombian Air Force,Embraer EMB314 Super Tucano,E314,Mil,Light Attack,Guns Guns Guns,Toucan Sam,Other Air Forces,https://w.wiki/6kJE
-AE6C01,86-0127,United States Air Force,Rockwell B-1B Lancer,B1,Mil,Cold Warrior,Strategic Bomber,Bone,USAF,https://w.wiki/3kLm
-AE6BD3,85-0064,United States Air Force,Rockwell B-1B Lancer,B1,Mil,Cold Warrior,Strategic Bomber,Bone,USAF,https://w.wiki/3kLm
+AE6C01,86-0127,USAF,Rockwell B-1B Lancer,B1,Mil,Cold Warrior,Strategic Bomber,Bone,USAF,https://w.wiki/3kLm
+AE6BD3,85-0064,USAF,Rockwell B-1B Lancer,B1,Mil,Cold Warrior,Strategic Bomber,Bone,USAF,https://w.wiki/3kLm
 06A248,A7-MAA,Qatar Emiri Air Force,C-17A Globemaster III,C17,Mil,Tactical Airlift,Globemaster,Touch The Sky With Glory,Other Air Forces,https://w.wiki/4ntJ
 AE1BFF,04-08706,United States Army,Boeing-Vertol CH-47F Chinook,H47,Mil,Choppa,Wocka Wocka,Twin Rotor,Toy Soldiers,https://en.wikipedia.org/wiki/Boeing_CH-47_Chinook
 AE04A9,99-00100,United States Army,Cessna UC-35A Citation,C560,Mil,VIP Transport,Bizjet,Must Be Nice,Toy Soldiers,https://www.army.mil
 AE681F,Tactical,United States Navy,Boeing P-8A Poseidon,P8,Mil,One Ping Only Vasily,Maritime Patrol,Eye In The Sky,Oxcart,https://w.wiki/3qBW
 AE5F50,169567,United States Navy,Boeing P-8A Poseidon,P8,Mil,One Ping Only Vasily,Maritime Patrol,Eye In The Sky,Oxcart,https://w.wiki/3qBW
+AE2936,74-22424,USAF,Bell TH-1H Iroquois,UH1,MilHuey,Get To The Choppa,To Fly Fight And Win,USAF,https://youtu.be/M4nFSdNNFQw
+AE2937,74-22502,USAF,Bell TH-1H Iroquois,UH1,Mil,Huey,Get To The Choppa,To Fly Fight And Win,USAF,https://youtu.be/M4nFSdNNFQw
+AE2938,????,USAF,Bell TH-1H Iroquois,UH1,Mil,Huey,Get To The Choppa,To Fly Fight And Win,USAF,https://youtu.be/M4nFSdNNFQw
+AE2939,74-22311,USAF,Bell TH-1H Iroquois,UH1,Mil,Huey,Get To The Choppa,To Fly Fight And Win,USAF,https://youtu.be/M4nFSdNNFQw
+AE20BC,74-22369,USAF,Bell TH-1H Iroquois,UH1,Mil,Huey,Get To The Choppa,To Fly Fight And Win,USAF,https://youtu.be/M4nFSdNNFQw
+AE20BD,72-21571,USAF,Bell TH-1H Iroquois,UH1,Mil,Huey,Get To The Choppa,To Fly Fight And Win,USAF,https://youtu.be/M4nFSdNNFQw
+AE20BE,73-21793,USAF,Bell TH-1H Iroquois,UH1,Mil,Huey,Get To The Choppa,To Fly Fight And Win,USAF,https://youtu.be/M4nFSdNNFQw
+AE20BF,72-21484,USAF,Bell TH-1H Iroquois,UH1,Mil,Huey,Get To The Choppa,To Fly Fight And Win,USAF,https://youtu.be/M4nFSdNNFQw

--- a/plane-alert-db.csv
+++ b/plane-alert-db.csv
@@ -13045,3 +13045,8 @@ AE20BC,74-22369,USAF,Bell TH-1H Iroquois,UH1,Mil,Huey,Get To The Choppa,To Fly F
 AE20BD,72-21571,USAF,Bell TH-1H Iroquois,UH1,Mil,Huey,Get To The Choppa,To Fly Fight And Win,USAF,https://youtu.be/M4nFSdNNFQw
 AE20BE,73-21793,USAF,Bell TH-1H Iroquois,UH1,Mil,Huey,Get To The Choppa,To Fly Fight And Win,USAF,https://youtu.be/M4nFSdNNFQw
 AE20BF,72-21484,USAF,Bell TH-1H Iroquois,UH1,Mil,Huey,Get To The Choppa,To Fly Fight And Win,USAF,https://youtu.be/M4nFSdNNFQw
+AE4BE9,74-22442,USAF,Bell TH-1H Iroquois,UH1,Mil,Huey,Get To The Choppa,To Fly Fight And Win,USAF,https://youtu.be/M4nFSdNNFQw
+AE4BEA,74-22428,USAF,Bell TH-1H Iroquois,UH1,Mil,Huey,Get To The Choppa,To Fly Fight And Win,USAF,https://youtu.be/M4nFSdNNFQw
+AE4BEB,72-21483,USAF,Bell TH-1H Iroquois,UH1,Mil,Huey,Get To The Choppa,To Fly Fight And Win,USAF,https://youtu.be/M4nFSdNNFQw
+AE4BEC,74-22463,USAF,Bell TH-1H Iroquois,UH1,Mil,Huey,Get To The Choppa,To Fly Fight And Win,USAF,https://youtu.be/M4nFSdNNFQw
+AE1849,71-20167,USAF,Bell TH-1H Iroquois,UH1,Mil,Huey,Get To The Choppa,To Fly Fight And Win,USAF,https://youtu.be/M4nFSdNNFQw

--- a/plane_images.csv
+++ b/plane_images.csv
@@ -13088,3 +13088,8 @@ AE20BC,https://live.staticflickr.com/65535/52692272767_4a63e91537_h.jpg,,,
 AE20BD,https://live.staticflickr.com/65535/52693282438_821c86956e_h.jpg,,,
 AE20BE,https://www.airport-data.com/images/aircraft/001/476/001476277.jpg,https://www.airport-data.com/images/aircraft/001/473/001473734.jpg,https://www.airport-data.com/images/aircraft/001/477/001477758.jpg,https://www.airport-data.com/images/aircraft/001/478/001478956.jpg
 AE20BF,https://cdn.jetphotos.com/full/2/74749_1274773234.jpg,,,
+AE4BE9,https://live.staticflickr.com/65535/47937188261_82739dcadb_k.jpg,https://live.staticflickr.com/2879/33607985020_5d9ca1f1d7_h.jpg,,
+AE4BEA,https://live.staticflickr.com/65535/52814750749_c103341cb6_h.jpg,,,
+AE4BEB,https://cdn.jetphotos.com/full/6/31152_1652613854.jpg,https://cdn.jetphotos.com/full/5/11415_1536682797.jpg,,
+AE4BEC,https://live.staticflickr.com/3948/33900655641_502bd40ae9_k.jpg,https://live.staticflickr.com/65535/52751849620_f73aeeb7c7_5k.jpg,https://live.staticflickr.com/3954/33900655031_47feecc817_k.jpg,https://live.staticflickr.com/65535/52750904342_3c9e05fb8b_5k.jpg
+AE1849,https://live.staticflickr.com/3927/33056547794_39e3f2ba4b_k.jpg,https://live.staticflickr.com/2915/33039430403_1a3c1309ad_k.jpg,https://live.staticflickr.com/65535/52740909043_c01e8faf15_5k.jpg,

--- a/plane_images.csv
+++ b/plane_images.csv
@@ -13080,3 +13080,11 @@ AE1BFF,https://www.airhistory.net/photos/0312034.jpg,https://api.time.com/wp-con
 AE04A9,https://cdn.jetphotos.com/full/5/93296_1625060800.jpg,https://cdn.jetphotos.com/full/5/99300_1566268118.jpg,https://cdn.jetphotos.com/full/1/24765_1235918123.jpg,https://cdn.jetphotos.com/full/1/54807_1158494987.jpg
 AE681F,,,,
 AE5F50,https://pbs.twimg.com/media/F06_JzbaIAInIER.jpg,https://pbs.twimg.com/media/F06_KNraQAQS2s4.jpg,https://pbs.twimg.com/media/F06_KnlagAErpjI.jpg,https://pbs.twimg.com/media/F06_LAzaMAEuJ2o.jpg
+AE2936,https://cdn.jetphotos.com/full/6/92702_1478973756.jpg,,,
+AE2937,https://cdn.jetphotos.com/full/5/68531_1529993536.jpg,,,
+AE2938,,,,
+AE2939,https://www.airhistory.net/photos/0419653.jpg,,,
+AE20BC,https://live.staticflickr.com/65535/52692272767_4a63e91537_h.jpg,,,
+AE20BD,https://live.staticflickr.com/65535/52693282438_821c86956e_h.jpg,,,
+AE20BE,https://www.airport-data.com/images/aircraft/001/476/001476277.jpg,https://www.airport-data.com/images/aircraft/001/473/001473734.jpg,https://www.airport-data.com/images/aircraft/001/477/001477758.jpg,https://www.airport-data.com/images/aircraft/001/478/001478956.jpg
+AE20BF,https://cdn.jetphotos.com/full/2/74749_1274773234.jpg,,,

--- a/plane_images.csv
+++ b/plane_images.csv
@@ -13093,3 +13093,4 @@ AE4BEA,https://live.staticflickr.com/65535/52814750749_c103341cb6_h.jpg,,,
 AE4BEB,https://cdn.jetphotos.com/full/6/31152_1652613854.jpg,https://cdn.jetphotos.com/full/5/11415_1536682797.jpg,,
 AE4BEC,https://live.staticflickr.com/3948/33900655641_502bd40ae9_k.jpg,https://live.staticflickr.com/65535/52751849620_f73aeeb7c7_5k.jpg,https://live.staticflickr.com/3954/33900655031_47feecc817_k.jpg,https://live.staticflickr.com/65535/52750904342_3c9e05fb8b_5k.jpg
 AE1849,https://live.staticflickr.com/3927/33056547794_39e3f2ba4b_k.jpg,https://live.staticflickr.com/2915/33039430403_1a3c1309ad_k.jpg,https://live.staticflickr.com/65535/52740909043_c01e8faf15_5k.jpg,
+AE4EB7,https://cdn.jetphotos.com/full/5/30639_1531587495.jpg,https://cdn.jetphotos.com/full/5/76902_1586637219.jpg,https://cdn.jetphotos.com/full/3/65973_1387518097.jpg,


### PR DESCRIPTION
## Describe your changes

TH-1s!

AE2936
AE2937
AE2938
AE2939
AE20BC
AE20BD
AE20BE
AE20BF

---
*introducing*
AE1849
AE4BE9
AE4BEA
AE4BEB
AE4BEC

and latecomer

AE4EB7

---

With pics on all but ae2938 because I couldn't find the tail code. Quite certain of these. Four of them flew in to KNEW yesterday, with some of them already in the mictronics database and two, ae2938 and ae20bf, not in mic's database. However, AE20BF was sending its tail code as its ADSB callsign, which matched sources elsewhere like helis.com. AE2938 was silent, so no idea what its code is. I added some others that were in Mic's database.

Also changed the two Bones added a while back to "USAF" instead of "United States Air Force" to match all the other USAF aircraft.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] While waiting for someone to review your request, please help review [another open pull request](https://github.com/sdr-enthusiasts/plane-alert-db/pulls) to support the maintainers.
