### PR TITLE
Update Phoenix PD, add Mesa PD, add Arizona DPS aircraft

### DIFF
--- a/plane-alert-db.csv
+++ b/plane-alert-db.csv
@@ -8359,13 +8359,23 @@ ABFF66,N872ST,Pennsylvania State Police,Bell 407GX,B407,Pol,Police Squad,The Cop
 AC15B0,N878ST,Pennsylvania State Police,Cessna 208B-EX Caravan,C208,Pol,Police Squad,The Cops,Surveillance,Police Forces,https://www.psp.pa.gov/Pages/default.aspx
 AC1967,N879ST,Pennsylvania State Police,Pilatus PC-12 47E,PC12,Pol,Police Squad,The Cops,Surveillance,Police Forces,https://www.psp.pa.gov/Pages/default.aspx
 A026A2,N109FB,Phoenix Police Dept,AgustaWestland AW.109E,A109,Pol,Police Squad,The Cops,Surveillance,Police Forces,https://www.phoenix.gov/police
-A6FD30,N55BE,Phoenix Police Dept,Cessna P210R Pressurized Centurion,P210,Pol,Police Squad,The Cops,Surveillance,Police Forces,https://www.phoenix.gov/police
 A406BB,N359FB,Phoenix Police Dept,Eurocopter AS350 Squirrel,AS50,Pol,Police Squad,The Cops,Copper Chopper,Police Forces,https://www.phoenix.gov/police
 A3FF4D,N357FB,Phoenix Police Dept,Eurocopter AS350 Squirrel,AS50,Pol,Police Squad,The Cops,Copper Chopper,Police Forces,https://www.phoenix.gov/police
 A3F071,N353FB,Phoenix Police Dept,Eurocopter AS350 Squirrel,AS50,Pol,Police Squad,The Cops,Copper Chopper,Police Forces,https://www.phoenix.gov/police
 A3ECBA,N352FB,Phoenix Police Dept,Eurocopter AS350 Squirrel,AS50,Pol,Police Squad,The Cops,Copper Chopper,Police Forces,https://www.phoenix.gov/police
 A3E903,N351FB,Phoenix Police Dept,Eurocopter EC120B Colibri,EC20,Pol,Police Squad,The Cops,Copper Chopper,Police Forces,https://www.phoenix.gov/police
 A816BC,N620FB,Phoenix Police Dept,Pilatus PC-12 47E,PC12,Pol,Police Squad,The Cops,Surveillance,Police Forces,https://www.phoenix.gov/police
+A81A73,N621FB,Phoenix Police Dept,Eurocopter AS350 Squirrel,AS50,Pol,Police Squad,The Cops,Copper Chopper,Police Forces,https://www.phoenix.gov/police
+A81E2A,N622FB,Phoenix Police Dept,Eurocopter AS350 Squirrel,AS50,Pol,Police Squad,The Cops,Copper Chopper,Police Forces,https://www.phoenix.gov/police
+A8985E,N653FB,Phoenix Police Dept,Eurocopter AS350 Squirrel,AS50,Pol,Police Squad,The Cops,Copper Chopper,Police Forces,https://www.phoenix.gov/police
+A4FB3C,N42WB,Mesa Police Dept,Cessna P210N Javelin,P210,Pol,Police Squad,The Cops,Surveillance,Police Forces,https://www.mesaazpolice.gov/about-mesa-pd/air-support-unit
+A63EC8,N501MP,Mesa Police Dept,Cessna 172 Skyhawk,C172,Pol,Police Squad,The Cops,Surveillance,Police Forces,https://www.mesaazpolice.gov/about-mesa-pd/air-support-unit
+A64DA4,N505MP,Mesa Police Dept,MD 369E,H500,Pol,Police Squad,The Cops,Copper Chopper,Police Forces,https://www.mesaazpolice.gov/about-mesa-pd/air-support-unit
+A6515B,N506MP,Mesa Police Dept,MD 369E,H500,Pol,Police Squad,The Cops,Copper Chopper,Police Forces,https://www.mesaazpolice.gov/about-mesa-pd/air-support-unit
+A724A9,N56AZ,Arizona Department of Public Safety,Bell 407,B407,Pol,Police Squad,The Cops,Copper Chopper,Police Forces,https://www.azdps.gov/organization/asd/aviation
+A773A7,N58AZ,Arizona Department of Public Safety,Bell 407,B407,Pol,Police Squad,The Cops,Copper Chopper,Police Forces,https://www.azdps.gov/organization/asd/aviation
+AC9A7A,N911AZ,Arizona Department of Public Safety,Bell 429 GlobalRanger,B429,Pol,Police Squad,The Cops,Copper Chopper,Police Forces,https://www.azdps.gov/organization/asd/aviation
+AD19F8,N943TB,Arizona Department of Public Safety,Bell 429 GlobalRanger,B429,Pol,Police Squad,The Cops,Copper Chopper,Police Forces,https://www.azdps.gov/organization/asd/aviation
 3DD798,D-HBWY,Police Baden-Wuerttemburg,Eurocopter EC145,EC45,Pol,Eye In The Sky,Police Squad,Copper Chopper,Police Forces,https://tinyurl.com/yckwuwhk
 3DD797,D-HBWX,Police Baden-Wuerttemburg,Eurocopter EC145,EC45,Pol,Police Squad,The Cops,Copper Chopper,Police Forces,https://en.wikipedia.org/wiki/Baden-W%C3%BCrttemberg_Police
 3DD6D1,D-HBPH,Police of Bayern,Eurocopter EC135 P2,EC35,Pol,Police Squad,You Aint Seen Me Right,Copper Chopper,Police Forces,https://en.wikipedia.org/wiki/Bavarian_State_Police


### PR DESCRIPTION
## Describe your changes
PLANE INFO:

Removed, aircraft is no longer registered to City of Phoenix:
A6FD30,N55BE

Added City of Phoenix PD:
A81A73,N621FB
A81E2A,N622FB
A8985E,N653FB

Added City of Mesa PD
A4FB3C,N42WB
A63EC8,N501MP
A64DA4,N505MP
A6515B,N506MP

Sources used: Name search or N-number search at https://registry.faa.gov/aircraftinquiry/Search/NameInquiry / https://registry.faa.gov/aircraftinquiry/Search/NNumberInquiry
Confirmed recent activity via FA where possible

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/sdr-enthusiasts/plane-alert-db/pulls) to support the maintainers.
