### PR TITLE
Worked on firefighting aircraft tags

### DIFF
--- a/plane-alert-db.csv
+++ b/plane-alert-db.csv
@@ -9132,307 +9132,307 @@ ADFDF8,82-8000,US Government,Boeing VC25A,B742,Gov,Air Force One,Government,POTU
 43C307,ZH827,Royal Navy Fleet Air Arm,EH-101 Merlin HM2,EH10,Mil,One Ping Only Vasily,AEW,Not A Wizard,Royal Navy Fleet Air Arm,https://youtu.be/jr0JaXfKj68
 43C306,ZH826,Royal Navy Fleet Air Arm,EH-101 Merlin HM2,EH10,Mil,One Ping Only Vasily,AEW,Not A Wizard,Royal Navy Fleet Air Arm,https://youtu.be/jr0JaXfKj68
 43C304,ZH824,Royal Navy Fleet Air Arm,EH-101 Merlin HM2,EH10,Mil,One Ping Only Vasily,AEW,Not A Wizard,Royal Navy Fleet Air Arm,https://youtu.be/jr0JaXfKj68
-A69072,N522AX,10 Tanker Air Carrier,Douglas DC-10 30,DC10,Civ,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.10tanker.com/
-A11CBB,N17085,10 Tanker Air Carrier,Douglas DC-10 30,DC10,Civ,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.10tanker.com/
-A7D27A,N603AX,10 Tanker Air Carrier,Douglas DC-10 30ER,DC10,Civ,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.10tanker.com/
-A7F642,N612AX,10 Tanker Air Carrier,Douglas DC-10 30ER,DC10,Civ,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.10tanker.com/
-A42299,N366AC,Aero Flite,Avro 146-RJ100,RJ1H,Civ,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://youtu.be/Qtyk7PoiKSo
-A48A3A,N392AC,Aero Flite,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://fireaviation.com/tag/aero-flite
-A47CBC,N389AC,Aero Flite,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://fireaviation.com/tag/aero-flite
-A47197,N386AC,Aero Flite,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://fireaviation.com/tag/aero-flite
-A46DE0,N385AC,Aero Flite,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://fireaviation.com/tag/aero-flite
-A85052,N635AC,AeroFlite,BAe 146-300,B463,Civ,Firebird,Aerial Firefighter,Wildfire,Sam Tân,https://youtu.be/Qtyk7PoiKSo
-C064F4,C-GMFZ,Air Spray,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.airspray.com
-C064F3,C-GMFY,Air Spray,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.airspray.com
-C064F2,C-GMFX,Air Spray,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.airspray.com
-C064F1,C-GMFW,Air Spray,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.airspray.com
-C0645E,C-GMAF,Air Spray,Canadair CL-215,CL2P,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.airspray.com
-C06463,C-GMAK,Air Spray,Canadair CL-215,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.airspray.com
-C048CF,C-GBOW,Air Spray,Canadair CL-215,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.airspray.com
-ACC962,N923AU,Airstrike Firefighters,Lockheed P-3A Orion,P3,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,http://www.airstrikefirefighters.com
-ACC5AB,N922AU,Airstrike Firefighters,Lockheed P-3A Orion,P3,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,http://www.airstrikefirefighters.com
-ACB0BF,N917AU,Airstrike Firefighters,Lockheed P-3A Orion,P3,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,http://www.airstrikefirefighters.com
-4921B0,CS-HMP,Bombeiros,Kamov Ka-32 A11BC,KA27,Civ,Double Vision,Hot Hot Hot,Helix,Sam Tân,https://www.pilotweb.aero/features/aerial-firefighting-in-portugal-1-5393140
-4921AE,CS-HMN,Bombeiros,Kamov Ka-32 A11BC,KA27,Civ,Double Vision,Hot Hot Hot,Helix,Sam Tân,https://www.pilotweb.aero/features/aerial-firefighting-in-portugal-1-5393140
-4921AD,CS-HMM,Bombeiros,Kamov Ka-32 A11BC,KA27,Civ,Double Vision,Hot Hot Hot,Helix,Sam Tân,https://www.pilotweb.aero/features/aerial-firefighting-in-portugal-1-5393140
-4921AC,CS-HML,Bombeiros,Kamov Ka-32 A11BC,KA27,Civ,Double Vision,Hot Hot Hot,Helix,Sam Tân,https://www.pilotweb.aero/features/aerial-firefighting-in-portugal-1-5393140
-4921AB,CS-HMK,Bombeiros,Kamov Ka-32 A11BC,KA27,Civ,Double Vision,Hot Hot Hot,Helix,Sam Tân,https://www.pilotweb.aero/features/aerial-firefighting-in-portugal-1-5393140
-E48A7E,PR-HGR,Brazilian Fire Service,AS350 Squirrel B2,AS50,Gov,Firebird,Aerial Firefighter,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Military_Firefighters_Corps
-A4EE4C,N417BT,Bridger AeroSpace,Canadair CL-215,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.bridgeraerospace.com
-A4E6DE,N415BT,Bridger AeroSpace,Canadair CL-215,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.bridgeraerospace.com
-C06743,C-GNCS,Buffalo Airways,Canadair CL-215,CL2P,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://buffaloairways.com/fire-suppression
-C041AC,C-FYWP,Buffalo Airways,Canadair CL-215,CL2P,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://buffaloairways.com/fire-suppression
-A62E21,N498DF,Cal Fire,Bell EH-1H Iroquois,UH1,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.fire.ca.gov
-A622FC,N495DF,Cal Fire,Bell EH-1H Iroquois,UH1,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.fire.ca.gov
-A61B8E,N493DF,Cal Fire,Bell EH-1H Iroquois,UH1,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.fire.ca.gov
-A60A59,N489DF,Cal Fire,Bell EH-1X Iroquois,UH1,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.fire.ca.gov
-A631D8,N499DF,Cal Fire,Bell UH-1H Iroquois,UH1,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.fire.ca.gov
-A5ECA1,N481DF,Cal Fire,Bell UH-1H Iroquois,UH1,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.fire.ca.gov
-A52E94,N433DF,Cal Fire,Grumman S-2A Tracker,S2P,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.fire.ca.gov
-A5726D,N450DF,Cal Fire,Grumman S-2F 3AT Tracker,S2P,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.fire.ca.gov
-A55D81,N445DF,Cal Fire,Grumman S-2F 3AT Tracker,S2P,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.fire.ca.gov
-A559CA,N444DF,Cal Fire,Grumman S-2F 3AT Tracker,S2P,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.fire.ca.gov
-A5525C,N442DF,Cal Fire,Grumman S-2F 3AT Tracker,S2P,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.fire.ca.gov
-A54EA5,N441DF,Cal Fire,Grumman S-2F 3AT Tracker,S2P,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.fire.ca.gov
-A54AEE,N440DF,Cal Fire,Grumman S-2F 3AT Tracker,S2P,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.fire.ca.gov
-A53D70,N437DF,Cal Fire,Grumman S-2F 3AT Tracker,S2P,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.fire.ca.gov
-A539B9,N436DF,Cal Fire,Grumman S-2F 3AT Tracker,S2P,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.fire.ca.gov
-A53602,N435DF,Cal Fire,Grumman S-2F 3AT Tracker,S2P,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.fire.ca.gov
-A5324B,N434DF,Cal Fire,Grumman S-2F 3AT Tracker,S2P,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.fire.ca.gov
-A52ADD,N432DF,Cal Fire,Grumman S-2F 3AT Tracker,S2P,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.fire.ca.gov
-A52726,N431DF,Cal Fire,Grumman S-2F 3AT Tracker,S2P,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.fire.ca.gov
-A519A8,N428DF,Cal Fire,Grumman S-2F 3AT Tracker,S2P,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.fire.ca.gov
-A515F1,N427DF,Cal Fire,Grumman S-2F 3AT Tracker,S2P,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.fire.ca.gov
-A5123A,N426DF,Cal Fire,Grumman S-2F 3AT Tracker,S2P,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.fire.ca.gov
-A50E83,N425DF,Cal Fire,Grumman S-2F 3AT Tracker,S2P,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.fire.ca.gov
-A50ACC,N424DF,Cal Fire,Grumman S-2F 3AT Tracker,S2P,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.fire.ca.gov
-A5035E,N422DF,Cal Fire,Grumman S-2F 3AT Tracker,S2P,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.fire.ca.gov
-A59025,N458DF,Cal Fire,Grumman S-2G Tracker,S2P,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.fire.ca.gov
-A568A6,N448DF,Cal Fire,Grumman S-2G Tracker,S2P,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.fire.ca.gov
-A51D5F,N429DF,Cal Fire,North American Rockwell OV-10A Bronco,V10,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.fire.ca.gov
-A4FFA7,N421DF,Cal Fire,North American Rockwell OV-10A Bronco,V10,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.fire.ca.gov
-A4F229,N418DF,Cal Fire,North American Rockwell OV-10A Bronco,V10,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.fire.ca.gov
-A4E704,N415DF,Cal Fire,North American Rockwell OV-10A Bronco,V10,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.fire.ca.gov
-A4E34D,N414DF,Cal Fire,North American Rockwell OV-10A Bronco,V10,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.fire.ca.gov
-A4DF96,N413DF,Cal Fire,North American Rockwell OV-10A Bronco,V10,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.fire.ca.gov
-A4D471,N410DF,Cal Fire,North American Rockwell OV-10A Bronco,V10,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.fire.ca.gov
-A4CE61,N409DF,Cal Fire,North American Rockwell OV-10A Bronco,V10,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.fire.ca.gov
-A4C6F3,N407DF,Cal Fire,North American Rockwell OV-10A Bronco,V10,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.fire.ca.gov
-A4B817,N403DF,Cal Fire,North American Rockwell OV-10A Bronco,V10,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.fire.ca.gov
-A4B460,N402DF,Cal Fire,North American Rockwell OV-10A Bronco,V10,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.fire.ca.gov
-A4B0A9,N401DF,Cal Fire,North American Rockwell OV-10A Bronco,V10,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.fire.ca.gov
-A4ACF2,N400DF,Cal Fire,North American Rockwell OV-10A Bronco,V10,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.fire.ca.gov
-A5C16B,N470DF,Cal Fire,North American Rockwell OV-10D Bronco,V10,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.fire.ca.gov
-A5BB5B,N469DF,Cal Fire,North American Rockwell OV-10D Bronco,V10,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.fire.ca.gov
-A4CAAA,N408DF,Cal Fire,North American Rockwell OV-10D Bronco,V10,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.fire.ca.gov
-A5F40F,N483DF,Cal Fire,Sikorsky S-70i,H60,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.fire.ca.gov
-A0956B,N137CG,Coulson Aviation,Boeing 737,B733,Civ,Flying Fire Extinguisher,Hot Hot Hot Hot,Wildfire,Sam Tân,https://www.coulsonaviationusa.com
-501F9A,895,Croatian Air Force,Air Tractor AT-802AF,AT8T,Mil,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://w.wiki/4mdB
-501F9F,866,Croatian Air Force,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Croatian_Air_Force
-71C985,HL9185,Daegu Fire Department,Eurocopter AS350 Squirrel B2,AS50,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://tinyurl.com/mw353ct4
-71D446,HL9446,Daegu Fire Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Hot Hot Hot Hot,Helix,Sam Tân,https://www.daegu.go.kr/119english/index.do
-71CE49,HL9649,Daegu Fire Dept,AgustaWestland AW.169,A169,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.daegu.go.kr/119english/index.do
-A30FE0,N297EA,Erickson Aero Tanker,McDonnell Douglas DC-9 87,MD87,Civ,Fire Bomber,Aerial Firefighter,Wildfire,Sam Tân,http://www.eatanker.com/
-71CE26,HL9626,Gangwon Fire Fighting Dept,AgustaWestland AW.139,A139,Gov,Aerial Firefighter,Wildfire,Hot Hot Hot Hot,Sam Tân,https://w.wiki/4mcn
-71CC85,HL9485,Gangwon Fire Fighting Dept,AgustaWestland AW.139,A139,Gov,Aerial Firefighter,Wildfire,Hot Hot Hot Hot,Sam Tân,https://w.wiki/4mcn
-71CC76,HL9476,Gangwon Fire Fighting Dept,AgustaWestland AW.139,A139,Gov,Aerial Firefighter,Wildfire,Hot Hot Hot Hot,Sam Tân,https://w.wiki/4mcn
-71CE13,HL9613,Gangwon Fire Fighting Dept,Sikorsky S-76 B,S76,Gov,Wildfire,Aerial Firefighter,Hot Hot Hot Hot,Sam Tân,https://w.wiki/4mcn
-C06F0D,C-GQBK,Government of Quebec,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.quebec.ca/en
-C06F0B,C-GQBI,Government of Quebec,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.quebec.ca/en
-C06F09,C-GQBG,Government of Quebec,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.quebec.ca/en
-C06F08,C-GQBF,Government of Quebec,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.quebec.ca/en
-C06F07,C-GQBE,Government of Quebec,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.quebec.ca/en
-C06F06,C-GQBD,Government of Quebec,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.quebec.ca/en
-C06F05,C-GQBC,Government of Quebec,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.quebec.ca/en
-C06F03,C-GQBA,Government of Quebec,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.quebec.ca/en
-C0348D,C-FTXK,Government of Quebec,Canadair CL-215,CL2P,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.quebec.ca/en
-C0348C,C-FTXJ,Government of Quebec,Canadair CL-215,CL2P,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.quebec.ca/en
-C03489,C-FTXG,Government of Quebec,Canadair CL-215,CL2P,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.quebec.ca/en
-C0537E,C-GFQB,Government of Quebec,Canadair CL-215,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.quebec.ca/en
-46A0C7,SX-HFG,Greek Fire Dept,Eurocopter AS332 Super Puma,AS32,Gov,Firebird,Aerial Firefighter,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Hellenic_Fire_Service
-46A0C6,SX-HFF,Greek Fire Dept,Eurocopter AS332 Super Puma,AS32,Gov,Firebird,Aerial Firefighter,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Hellenic_Fire_Service
-46A0C5,SX-HFE,Greek Fire Dept,MBB-Kawasaki BK 117 C-1,BK17,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://w.wiki/4mco
-46A0C4,SX-HFD,Greek Fire Dept,MBB-Kawasaki BK 117 C-1,BK17,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://w.wiki/4mco
-71D456,HL9456,Gyong-Gi Fire Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Hot Hot Hot Hot,Helix,Sam Tân,https://119.gg.go.kr/eng/?page_id=447
-AC9AE5,N911FF,Hawaii County Fire Dept,Bell 206L Long Ranger,B06,Gov,Firebird,Aerial Firefighter,Wildfire,Sam Tân,https://www.hawaiicounty.gov/departments/fire
-AD2ED1,N949CH,Heligroup Fire,Boeing-Vertol CH-47D Chinook,H47,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://chiaviation.com/about
-AD2B1A,N948CH,Heligroup Fire,Boeing-Vertol CH-47D Chinook,H47,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://chiaviation.com/about
-AD2763,N947CH,Heligroup Fire,Boeing-Vertol CH-47D Chinook,H47,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://chiaviation.com/about
-ACC29C,N921HM,Heligroup Fire,Eurocopter AS350 Squirrel,AS50,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://chiaviation.com/about
-AC8D1E,N908CH,Heligroup Fire,Sikorsky S-61 N,S61,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://chiaviation.com/about
-AC8967,N907CH,Heligroup Fire,Sikorsky S-61 N,S61,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://chiaviation.com/about
-AB456D,N825WL,Heligroup Fire,Sikorsky S-61 N,S61,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://chiaviation.com/about
-71CA77,HL9277,Incheon Fire & Safety Dept,AgustaWestland AW.139,A139,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://w.wiki/4mcn
-71CC08,HL9408,Incheon Fire & Safety Dept,Bell 230,B230,Gov,Wildfire,Aerial Firefighter,Airworlf,Sam Tân,https://en.wikipedia.org/wiki/Fire_services_in_South_Korea
-32003E,VF-145,Italian Fire Service,AgustaWestland AW.139,A139,Gov,Aerial Firefighter,Firebird,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Vigili_del_Fuoco
-32003D,VF-144,Italian Fire Service,AgustaWestland AW.139,A139,Gov,Aerial Firefighter,Firebird,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Vigili_del_Fuoco
-32003C,VF-143,Italian Fire Service,AgustaWestland AW.139,A139,Gov,Aerial Firefighter,Firebird,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Vigili_del_Fuoco
-32002D,VF-140,Italian Fire Service,AgustaWestland AW.139,A139,Gov,Aerial Firefighter,Firebird,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Vigili_del_Fuoco
-32002C,VF-139,Italian Fire Service,AgustaWestland AW.139,A139,Gov,Aerial Firefighter,Firebird,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Vigili_del_Fuoco
-320050,VF-149,Italian Fire Service,AgustaWestland AW.139,A139,Gov,Aerial Firefighter,Firebird,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Vigili_del_Fuoco
-320044,VF-147,Italian Fire Service,AgustaWestland AW.139,A139,Gov,Aerial Firefighter,Firebird,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Vigili_del_Fuoco
-320037,VF-142,Italian Fire Service,AgustaWestland AW.139,A139,Gov,Aerial Firefighter,Firebird,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Vigili_del_Fuoco
-320036,VF-141,Italian Fire Service,AgustaWestland AW.139,A139,Gov,Aerial Firefighter,Firebird,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Vigili_del_Fuoco
-320035,VF-84,Italian Fire Service,AW.109E Power,A109,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Vigili_del_Fuoco
-320034,VF-82,Italian Fire Service,AW.109E Power,A109,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Vigili_del_Fuoco
-320033,VF-81,Italian Fire Service,AW.109E Power,A109,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Vigili_del_Fuoco
-320032,VF-80,Italian Fire Service,AW.109E Power,A109,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Vigili_del_Fuoco
-30041D,I-DPCS,Italian Protezione Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Protezione_Civile
-3003B6,I-DPCN,Italian Protezione Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Protezione_Civile
-3002ED,I-DPCR,Italian Protezione Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Protezione_Civile
-30024C,I-DPCH,Italian Protezione Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Protezione_Civile
-30024B,I-DPCG,Italian Protezione Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Protezione_Civile
-30024A,I-DPCF,Italian Protezione Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Protezione_Civile
-30023F,I-DPCO,Italian Protezione Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Protezione_Civile
-30023E,I-DPCE,Italian Protezione Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Protezione_Civile
-30023D,I-DPCD,Italian Protezione Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Protezione_Civile
-300337,I-DPCC,Italian Protezione Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Protezione_Civile
-300248,I-DPCZ,Italian Protezione Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Protezione_Civile
-300245,I-DPCW,Italian Protezione Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Protezione_Civile
-300244,I-DPCV,Italian Protezione Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Protezione_Civile
-300243,I-DPCU,Italian Protezione Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Protezione_Civile
-300242,I-DPCT,Italian Protezione Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Protezione_Civile
-300241,I-DPCQ,Italian Protezione Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Protezione_Civile
-300240,I-DPCP,Italian Protezione Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Protezione_Civile
-71CE33,HL9633,Jeju Fire Safety Division,KAI KUH-1 Surion EM,SURN,Gov,Flying Fire Extinguisher,Aerial Firefighter,Fire Festival,Sam Tân,https://www.visitjeju.net/u/5QH
-AC9B1B,N911HK,Kaui Fire Department,MD 369FF,H500,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.kauai.gov/Fire
-845BF6,JA10KC,Kitakyushu Fire Dept,AS365 N3 Dauphin,AS65,Gov,Firebird,Aerial Firefighter,Wildfire,Sam Tân,https://www.city.kitakyushu.lg.jp/shoubou/shoubou.html
-71CC37,HL9437,Korea Forestry Department,Kamov Ka-32 A,KA27,Civ,Double Vision,Hot Hot Hot Hot,Helix,Sam Tân,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
-71CC20,HL9420,Korea Forestry Department,Kamov Ka-32 A,KA27,Civ,Double Vision,Hot Hot Hot Hot,Helix,Sam Tân,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
-71D426,HL9426,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Hot Hot Hot Hot,Helix,Sam Tân,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
-71D412,HL9412,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Hot Hot Hot Hot,Helix,Sam Tân,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
-71D411,HL9411,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Hot Hot Hot Hot,Helix,Sam Tân,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
-71D410,HL9410,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Hot Hot Hot Hot,Helix,Sam Tân,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
-71D409,HL9409,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Hot Hot Hot Hot,Helix,Sam Tân,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
-71CC36,HL9436,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Hot Hot Hot Hot,Helix,Sam Tân,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
-71CC35,HL9435,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Hot Hot Hot Hot,Helix,Sam Tân,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
-71CC34,HL9434,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Hot Hot Hot Hot,Helix,Sam Tân,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
-71CC33,HL9433,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Hot Hot Hot Hot,Helix,Sam Tân,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
-71CC32,HL9432,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Hot Hot Hot Hot,Helix,Sam Tân,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
-71CC31,HL9431,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Hot Hot Hot Hot,Helix,Sam Tân,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
-71CC30,HL9430,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Hot Hot Hot Hot,Helix,Sam Tân,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
-71CC29,HL9429,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Hot Hot Hot Hot,Helix,Sam Tân,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
-71CC28,HL9428,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Hot Hot Hot Hot,Helix,Sam Tân,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
-71CC27,HL9427,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Hot Hot Hot Hot,Helix,Sam Tân,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
-71CC25,HL9425,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Hot Hot Hot Hot,Helix,Sam Tân,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
-71CC24,HL9424,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Hot Hot Hot Hot,Helix,Sam Tân,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
-71CC23,HL9423,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Hot Hot Hot Hot,Helix,Sam Tân,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
-71CC22,HL9422,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Hot Hot Hot Hot,Helix,Sam Tân,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
-71CC21,HL9421,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Hot Hot Hot Hot,Helix,Sam Tân,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
-71CC18,HL9418,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Hot Hot Hot Hot,Helix,Sam Tân,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
-71CC17,HL9417,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Hot Hot Hot Hot,Helix,Sam Tân,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
-71CC16,HL9416,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Hot Hot Hot Hot,Helix,Sam Tân,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
-71CC15,HL9415,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Hot Hot Hot Hot,Helix,Sam Tân,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
-71CC14,HL9414,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Hot Hot Hot Hot,Helix,Sam Tân,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
-8408F7,JA02FD,Kyoto City Fire Dept,AS365 N3 Dauphin,AS65,Gov,Firebird,Aerial Firefighter,Wildfire,Sam Tân,https://www.city.kyoto.lg.jp/shobo/page/0000002888.html
-71D462,HL9462,Kyungbuk Fire Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Hot Hot Hot Hot,Helix,Sam Tân,https://en.wikipedia.org/wiki/Fire_services_in_South_Korea
-A33266,N305FD,Los Angeles Fire Department,AgustaWestland AW.139,A139,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.lafd.org
-A32EAF,N304FD,Los Angeles Fire Department,AgustaWestland AW.139,A139,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.lafd.org
-A32AF8,N303FD,Los Angeles Fire Department,AgustaWestland AW.139,A139,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.lafd.org
-A32741,N302FD,Los Angeles Fire Department,AgustaWestland AW.139,A139,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.lafd.org
-A3238A,N301FD,Los Angeles Fire Department,AgustaWestland AW.139,A139,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.lafd.org
-A3361D,N306FD,Los Angeles Fire Department,Bell 206B Jet Ranger,B06,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.lafd.org
-A117CF,N17LA,Los Angeles Fire Department,Bell 412EP,B412,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.lafd.org
-A054AD,N120LA,Los Angeles Fire Department,Bell 412EP,B412,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.lafd.org
-A0A152,N14LA,Los Angeles Fire Department,Bell 412EP,B412,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.lafd.org
-A13F4E,N18LA,Los Angeles Fire Department,Bell 412HP,B412,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.lafd.org
-A9F008,N73985,Los Angeles Fire Department,Bell 47G-3B-1,B47G,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.lafd.org
-AB358D,N821LA,Los Angeles Fire Department,Sikorsky S-70,H60,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.lafd.org
-A16926,N190LA,Los Angeles Fire Department,Sikorsky S-70A,H60,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.lafd.org
-A0F2A9,N160LA,Los Angeles Fire Department,Sikorsky S-70A,H60,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.lafd.org
-A0C8D1,N15LA,Los Angeles Fire Department,Sikorsky S-70A,H60,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.lafd.org
-AB3944,N822LA,Los Angeles Fire Department,Sikorsky S-70i,H60,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.lafd.org
-C07044,C-GQNJ,Mag Aerospace,B200 Super King Air,BE20,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,http://www.magaero.ca
-C05D93,C-GJLI,Mag Aerospace,B200 Super King Air,BE20,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,http://www.magaero.ca
-C01B5B,C-FKJI,Mag Aerospace,B200 Super King Air,BE20,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,http://www.magaero.ca
-C07927,C-GTWW,Mag Aerospace,C90 King Air,BE9L,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,http://www.magaero.ca
-750476,9M-BOF,Malaysia Fire & Rescue Dept,AgustaWestland AW.189,A189,Gov,Firebird,Aerial Firefighter,Wildfire,Sam Tân,https://tinyurl.com/2p8jab29
-750442,9M-BOE,Malaysia Fire & Rescue Dept,AgustaWestland AW.189,A189,Gov,Firebird,Aerial Firefighter,Wildfire,Sam Tân,https://tinyurl.com/2p8jab29
-A1D480,N217LC,Miami Dade Fire & Rescue,AgustaWestland AW.139,A139,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://tinyurl.com/2t4kjxez
-A1B0B8,N208LC,Miami Dade Fire & Rescue,AgustaWestland AW.139,A139,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://tinyurl.com/2t4kjxez
-AC9AE3,N911FD,Miami Dade Fire & Rescue,Bell 412EP,B412,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.miamidade.gov/global/fire/home.page
-AC9A72,N911AR,Miami Dade Fire & Rescue,Bell 412EP,B412,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.miamidade.gov/global/fire/home.page
-A2237E,N237LC,Miami Dade Fire & Rescue,Bell 412EP,B412,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.miamidade.gov/global/fire/home.page
-A21FC7,N236LC,Miami Dade Fire & Rescue,Bell 412EP,B412,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.miamidade.gov/global/fire/home.page
-733470,EP-MCP,National Fire Service,Tupolev Tu-154M,T154,Gov,Firebird,Aerial Firefighter,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Russian_State_Fire_Service
-A0110E,N103NJ,New Jersey Forest Fire Service,Bell 206B Jet Ranger,B06,Gov,Firebird,Aerial Firefighter,Wildfire,Sam Tân,https://www.nj.gov/dep/parksandforests/fire
-A00D57,N102NJ,New Jersey Forest Fire Service,Bell 206B Jet Ranger,B06,Gov,Firebird,Aerial Firefighter,Wildfire,Sam Tân,https://www.nj.gov/dep/parksandforests/fire
-A01C33,N106NJ,New Jersey Forest Fire Service,Bell UH-1H Iroquois,UH1,Gov,Firebird,Aerial Firefighter,Wildfire,Sam Tân,https://www.nj.gov/dep/parksandforests/fire
-A0187C,N105NJ,New Jersey Forest Fire Service,Bell UH-1H Iroquois,UH1,Gov,Firebird,Aerial Firefighter,Wildfire,Sam Tân,https://www.nj.gov/dep/parksandforests/fire
-7C6B99,VH-VJF,NSW Rural Fire Service,Bell 412EP,B412,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.rfs.nsw.gov.au
-7C6B97,VH-VJD,NSW Rural Fire Service,Bell 412EP,B412,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.rfs.nsw.gov.au
-A72ADA,N561CG,NSW Rural Fire Service,Cessna Citation V,C560,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.rfs.nsw.gov.au
-C06A56,C-GOGZ,Ontario MNR Aviation Service,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.ontario.ca/page/aviation-services
-C06A55,C-GOGY,Ontario MNR Aviation Service,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.ontario.ca/page/aviation-services
-C06A54,C-GOGX,Ontario MNR Aviation Service,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.ontario.ca/page/aviation-services
-C06A53,C-GOGW,Ontario MNR Aviation Service,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.ontario.ca/page/aviation-services
-C06A44,C-GOGH,Ontario MNR Aviation Service,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.ontario.ca/page/aviation-services
-C06A43,C-GOGG,Ontario MNR Aviation Service,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.ontario.ca/page/aviation-services
-C06A42,C-GOGF,Ontario MNR Aviation Service,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.ontario.ca/page/aviation-services
-C06A41,C-GOGE,Ontario MNR Aviation Service,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.ontario.ca/page/aviation-services
-C06A40,C-GOGD,Ontario MNR Aviation Service,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.ontario.ca/page/aviation-services
-C041A7,C-FYWK,Province of Newfoundland,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.gov.nl.ca
-C02583,C-FOFI,Province of Newfoundland,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.gov.nl.ca
-C02341,C-FNJC,Province of Newfoundland,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.gov.nl.ca
-C015C6,C-FIGJ,Province of Newfoundland,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.gov.nl.ca
-C04D58,C-GDHN,Province of Northwest Territories,Canadair CL-215,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.gov.nt.ca
-C04BDC,C-GCSX,Province of Northwest Territories,Canadair CL-215,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.gov.nt.ca
-C049D1,C-GBYU,Province of Northwest Territories,Canadair CL-215,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.gov.nt.ca
-C048D6,C-GBPD,Province of Northwest Territories,Canadair CL-215,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.gov.nt.ca
-C041BD,C-FYXG,Province of Saskatchewan,Canadair CL-215,CL2P,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.saskatchewan.ca
-C041AB,C-FYWO,Province of Saskatchewan,Canadair CL-215,CL2P,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.saskatchewan.ca
-C028B7,C-FPKW,Province of Saskatchewan,Canadair CL-215,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.saskatchewan.ca
-C00091,C-FAFO,Province of Saskatchewan,Canadair CL-215,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.saskatchewan.ca
-02010A,CN-ATQ,Royal Moroccan Air Force,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Fire,Sam Tân,https://en.wikipedia.org/wiki/Royal_Moroccan_Air_Force
-0200EE,CN-ATN,Royal Moroccan Air Force,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Fire,Sam Tân,https://en.wikipedia.org/wiki/Royal_Moroccan_Air_Force
-0200E6,CN-ATM,Royal Moroccan Air Force,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Fire,Sam Tân,https://en.wikipedia.org/wiki/Royal_Moroccan_Air_Force
-020109,CN-ATP,Royal Moroccan Air Force,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Fire,Sam Tân,https://en.wikipedia.org/wiki/Royal_Moroccan_Air_Force
-020107,CN-ATO,Royal Moroccan Air Force,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Fire,Sam Tân,https://en.wikipedia.org/wiki/Royal_Moroccan_Air_Force
-A042FE,N116FD,Sacramento Metropolitan Fire District,Bell UH-1H Iroquois,UH1,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://metrofire.ca.gov
-A03F47,N115FD,Sacramento Metropolitan Fire District,Bell UH-1H Iroquois,UH1,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://metrofire.ca.gov
-A2D346,N281SD,San Diego City Fire Dept,Bell 212,B212,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.sandiego.gov/fire
-A2D6FD,N282SD,San Diego City Fire Dept,Bell 412EP,B412,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.sandiego.gov/fire
-A2DAB4,N283SD,San Diego City Fire Dept,Sikorsky S-70,H60,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.sandiego.gov/fire
-A1A588,N205KS,Santa Barbara County Fire Department,Bell UH-1H Iroquois,UH1,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.sbcfire.com
-AD6C94,N964SB,Santa Barbara County Fire Department,Sikorsky HH-60L Blackhawk,H60,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.sbcfire.com
-3B7B65,F-ZBFJ,Securite Civile,B200 Super King Air,BE20,Gov,Water Bomber Group,Aerial Firefighter,Wildfire,Sam Tân,https://w.wiki/4nsA
-3B7B76,F-ZBFY,Securite Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://w.wiki/4nsA
-3B7B75,F-ZBFV,Securite Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://w.wiki/4nsA
-3B7B74,F-ZBFW,Securite Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://w.wiki/4nsA
-3B7B73,F-ZBEG,Securite Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://w.wiki/4nsA
-3B7B72,F-ZBEU,Securite Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://w.wiki/4nsA
-3B7B71,F-ZBME,Securite Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://w.wiki/4nsA
-3B7B70,F-ZBMF,Securite Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://w.wiki/4nsA
-3B7B6F,F-ZBFP,Securite Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://w.wiki/4nsA
-3B7B6E,F-ZBFS,Securite Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://w.wiki/4nsA
-3B7B6D,F-ZBFN,Securite Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://w.wiki/4nsA
-3B7B6C,F-ZBFX,Securite Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://w.wiki/4nsA
-3B7B6B,F-ZBMG,Securite Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://w.wiki/4nsA
-3B7B3F,F-ZBMI,Securite Civile,DHC-8-400 MR,DH8D,Gov,Multi Role,Aerial Firefighter,Wildfire,Sam Tân,https://w.wiki/4nsA
-C06DC8,C-GPOX,Securite Civile,DHC-8-402,DH8D,Gov,Multi Role,Aerial Firefighter,Wildfire,Sam Tân,https://w.wiki/4nsA
-3B7B86,F-ZBMC,Securite Civile,DHC-8-402,DH8D,Gov,Multi Role,Aerial Firefighter,Wildfire,Sam Tân,https://w.wiki/4nsA
-3B7B63,F-ZBMH,Securite Civile,DHC-8-402,DH8D,Gov,Multi Role,Aerial Firefighter,Wildfire,Sam Tân,https://w.wiki/4nsA
-3B7B90,F-ZBQA,Securite Civile,Eurocopter EC145,EC45,Gov,Search And Rescue,Aerial Firefighter,EMS,Sam Tân,https://w.wiki/4nsA
-3B7B9A,F-ZBPQ,Securite Civile,Eurocopter EC145,EC45,Gov,Search And Rescue,Aerial Firefighter,EMS,Sam Tân,https://w.wiki/4nsA
-3B7B98,F-ZBPS,Securite Civile,Eurocopter EC145,EC45,Gov,Search And Rescue,Aerial Firefighter,EMS,Sam Tân,https://w.wiki/4nsA
-3B7BA2,F-ZBPI,Securite Civile,Eurocopter EC145,EC45,Gov,Search And Rescue,Aerial Firefighter,EMS,Sam Tân,https://w.wiki/4nsA
-71CC48,HL9448,Seoul Metro Fire & Disaster Dept,AS365 Dauphin,AS65,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://fire.seoul.go.kr/english
-71CC47,HL9447,Seoul Metro Fire & Disaster Dept,AS365 Dauphin,AS65,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://fire.seoul.go.kr/english
-71CE39,HL9639,Seoul Metro Fire & Disaster Dept,AW.189,A189,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://fire.seoul.go.kr/english
-0093C4,ZS-HLZ,South African Fire Fighting Association,Bell UH-1H Iroquois,UH1,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.fpasa.co.za
-0093C2,ZS-HLX,South African Fire Fighting Association,Bell UH-1H Iroquois,UH1,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.fpasa.co.za
-0093B5,ZS-HLK,South African Fire Fighting Association,Bell UH-1H Iroquois,UH1,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.fpasa.co.za
-0093AB,ZS-HLA,South African Fire Fighting Association,Bell UH-1H Iroquois,UH1,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.fpasa.co.za
-71D486,HL9486,South Korean National Park Authority,Kamov Ka-32 A,KA27,Civ,Double Vision,Hot Hot Hot Hot,Helix,Sam Tân,https://english.knps.or.kr
-71D481,HL9481,South Korean National Park Authority,Kamov Ka-32 A,KA27,Civ,Double Vision,Hot Hot Hot Hot,Helix,Sam Tân,https://english.knps.or.kr
-71D465,HL9465,South Korean National Park Authority,Kamov Ka-32 T,KA27,Civ,Double Vision,Hot Hot Hot Hot,Helix,Sam Tân,https://english.knps.or.kr
-354641,UD.14-03,Spanish Air Force,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Spanish_Air_Force
-353042,UD.14-02,Spanish Air Force,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Spanish_Air_Force
-353041,UD.14-01,Spanish Air Force,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Spanish_Air_Force
-344609,UD.14-04,Spanish Air Force,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Spanish_Air_Force
-3464D9,EC-NKY,Titan Firefighting,Air Tractor AT-802,AT8T,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://titanfirefighting.com/en/home
-34634A,EC-NDU,Titan Firefighting,Air Tractor AT-802,AT8T,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://titanfirefighting.com/en/home
-845E9C,JA119E,Tokyo Fire Department,AS365 N3 Dauphin,AS65,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://w.wiki/4mcq
-8623D6,JA62HC,Tokyo Fire Department,Eurocopter EC225 LP,EC25,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://w.wiki/4mcq
-845EAE,JA119Y,Tokyo Fire Department,Eurocopter EC225 LP,EC35,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://w.wiki/4mcq
-846B07,JA14TD,Tokyo Fire Dept,AgustaWestland AW.139,A139,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://w.wiki/4mcq
-85209F,JA35AR,Tokyo Fire Dept,AgustaWestland AW.169,A169,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://w.wiki/4mcq
-84C3DD,JA24HB,Tokyo Fire Dept,AgustaWestland AW.189,A189,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://w.wiki/4mcq
-4BD16D,TC-TKM,Turkish Air Force,Canadair CL-215,CL2P,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.hvkk.tsk.tr
-4BD16C,TC-TKL,Turkish Air Force,Canadair CL-215,CL2P,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.hvkk.tsk.tr
-4BD16B,TC-TKK,Turkish Air Force,Canadair CL-215,CL2P,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.hvkk.tsk.tr
-4BD16A,TC-TKJ,Turkish Air Force,Canadair CL-215,CL2P,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.hvkk.tsk.tr
-4BD168,TC-TKH,Turkish Air Force,Canadair CL-215,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.hvkk.tsk.tr
-4BD17A,TC-TKZ,Turkish Department of Forestation,Canadair CL-215,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.tarimorman.gov.tr/
-4BD179,TC-TKY,Turkish Department of Forestation,Canadair CL-215,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.tarimorman.gov.tr/
-4BD176,TC-TKV,Turkish Department of Forestation,Canadair CL-215,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.tarimorman.gov.tr/
-4BD174,TC-TKT,Turkish Department of Forestation,Canadair CL-215,CL2T,Gov,Super Scooper,Aerial Firefighter,Wildfire,Sam Tân,https://www.tarimorman.gov.tr/
-71D407,HL9407,Ulsan Fire Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Hot Hot Hot Hot,Helix,Sam Tân,https://en.wikipedia.org/wiki/Fire_services_in_South_Korea
-A1A4B7,N205BH,Ventura County Fire Department,Bell EH-1H Iroquois,UH1,Civ,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://vcfd.org
-A95413,N70VC,Ventura County Fire Department,Sikorsky HH-60L Blackhawk,H60,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://vcfd.org
-A7C6C4,N60VC,Ventura County Fire Department,Sikorsky HH-60L Blackhawk,H60,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://vcfd.org
-C03194,C-FSUD,Ventura County Fire Department,Turbo Commander 690B,AC90,Gov,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,http://www.magaero.ca
-AAE162,N80VC,Ventura County Fire Department,UH-60L Blackhawk,H60,Civ,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://vcfd.org
+A69072,N522AX,10 Tanker Air Carrier,Douglas DC-10 30,DC10,Civ,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.10tanker.com/
+A11CBB,N17085,10 Tanker Air Carrier,Douglas DC-10 30,DC10,Civ,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.10tanker.com/
+A7D27A,N603AX,10 Tanker Air Carrier,Douglas DC-10 30ER,DC10,Civ,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.10tanker.com/
+A7F642,N612AX,10 Tanker Air Carrier,Douglas DC-10 30ER,DC10,Civ,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.10tanker.com/
+A42299,N366AC,Aero Flite,Avro 146-RJ100,RJ1H,Civ,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://youtu.be/Qtyk7PoiKSo
+A48A3A,N392AC,Aero Flite,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://fireaviation.com/tag/aero-flite
+A47CBC,N389AC,Aero Flite,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://fireaviation.com/tag/aero-flite
+A47197,N386AC,Aero Flite,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://fireaviation.com/tag/aero-flite
+A46DE0,N385AC,Aero Flite,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://fireaviation.com/tag/aero-flite
+A85052,N635AC,AeroFlite,BAe 146-300,B463,Civ,Firebird,Air Attack,Wildfire,Aerial Firefighter,https://youtu.be/Qtyk7PoiKSo
+C064F4,C-GMFZ,Air Spray,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.airspray.com
+C064F3,C-GMFY,Air Spray,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.airspray.com
+C064F2,C-GMFX,Air Spray,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.airspray.com
+C064F1,C-GMFW,Air Spray,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.airspray.com
+C0645E,C-GMAF,Air Spray,Canadair CL-215,CL2P,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.airspray.com
+C06463,C-GMAK,Air Spray,Canadair CL-215,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.airspray.com
+C048CF,C-GBOW,Air Spray,Canadair CL-215,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.airspray.com
+ACC962,N923AU,Airstrike Firefighters,Lockheed P-3A Orion,P3,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,http://www.airstrikefirefighters.com
+ACC5AB,N922AU,Airstrike Firefighters,Lockheed P-3A Orion,P3,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,http://www.airstrikefirefighters.com
+ACB0BF,N917AU,Airstrike Firefighters,Lockheed P-3A Orion,P3,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,http://www.airstrikefirefighters.com
+4921B0,CS-HMP,Bombeiros,Kamov Ka-32 A11BC,KA27,Civ,Double Vision,Air Attack,Helix,Aerial Firefighter,https://www.pilotweb.aero/features/aerial-firefighting-in-portugal-1-5393140
+4921AE,CS-HMN,Bombeiros,Kamov Ka-32 A11BC,KA27,Civ,Double Vision,Air Attack,Helix,Aerial Firefighter,https://www.pilotweb.aero/features/aerial-firefighting-in-portugal-1-5393140
+4921AD,CS-HMM,Bombeiros,Kamov Ka-32 A11BC,KA27,Civ,Double Vision,Air Attack,Helix,Aerial Firefighter,https://www.pilotweb.aero/features/aerial-firefighting-in-portugal-1-5393140
+4921AC,CS-HML,Bombeiros,Kamov Ka-32 A11BC,KA27,Civ,Double Vision,Air Attack,Helix,Aerial Firefighter,https://www.pilotweb.aero/features/aerial-firefighting-in-portugal-1-5393140
+4921AB,CS-HMK,Bombeiros,Kamov Ka-32 A11BC,KA27,Civ,Double Vision,Air Attack,Helix,Aerial Firefighter,https://www.pilotweb.aero/features/aerial-firefighting-in-portugal-1-5393140
+E48A7E,PR-HGR,Brazilian Fire Service,AS350 Squirrel B2,AS50,Gov,Firebird,Air Attack,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Military_Firefighters_Corps
+A4EE4C,N417BT,Bridger AeroSpace,Canadair CL-215,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.bridgeraerospace.com
+A4E6DE,N415BT,Bridger AeroSpace,Canadair CL-215,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.bridgeraerospace.com
+C06743,C-GNCS,Buffalo Airways,Canadair CL-215,CL2P,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://buffaloairways.com/fire-suppression
+C041AC,C-FYWP,Buffalo Airways,Canadair CL-215,CL2P,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://buffaloairways.com/fire-suppression
+A62E21,N498DF,Cal Fire,Bell EH-1H Iroquois,UH1,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.fire.ca.gov
+A622FC,N495DF,Cal Fire,Bell EH-1H Iroquois,UH1,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.fire.ca.gov
+A61B8E,N493DF,Cal Fire,Bell EH-1H Iroquois,UH1,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.fire.ca.gov
+A60A59,N489DF,Cal Fire,Bell EH-1X Iroquois,UH1,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.fire.ca.gov
+A631D8,N499DF,Cal Fire,Bell UH-1H Iroquois,UH1,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.fire.ca.gov
+A5ECA1,N481DF,Cal Fire,Bell UH-1H Iroquois,UH1,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.fire.ca.gov
+A52E94,N433DF,Cal Fire,Grumman S-2A Tracker,S2P,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.fire.ca.gov
+A5726D,N450DF,Cal Fire,Grumman S-2F 3AT Tracker,S2P,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.fire.ca.gov
+A55D81,N445DF,Cal Fire,Grumman S-2F 3AT Tracker,S2P,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.fire.ca.gov
+A559CA,N444DF,Cal Fire,Grumman S-2F 3AT Tracker,S2P,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.fire.ca.gov
+A5525C,N442DF,Cal Fire,Grumman S-2F 3AT Tracker,S2P,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.fire.ca.gov
+A54EA5,N441DF,Cal Fire,Grumman S-2F 3AT Tracker,S2P,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.fire.ca.gov
+A54AEE,N440DF,Cal Fire,Grumman S-2F 3AT Tracker,S2P,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.fire.ca.gov
+A53D70,N437DF,Cal Fire,Grumman S-2F 3AT Tracker,S2P,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.fire.ca.gov
+A539B9,N436DF,Cal Fire,Grumman S-2F 3AT Tracker,S2P,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.fire.ca.gov
+A53602,N435DF,Cal Fire,Grumman S-2F 3AT Tracker,S2P,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.fire.ca.gov
+A5324B,N434DF,Cal Fire,Grumman S-2F 3AT Tracker,S2P,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.fire.ca.gov
+A52ADD,N432DF,Cal Fire,Grumman S-2F 3AT Tracker,S2P,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.fire.ca.gov
+A52726,N431DF,Cal Fire,Grumman S-2F 3AT Tracker,S2P,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.fire.ca.gov
+A519A8,N428DF,Cal Fire,Grumman S-2F 3AT Tracker,S2P,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.fire.ca.gov
+A515F1,N427DF,Cal Fire,Grumman S-2F 3AT Tracker,S2P,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.fire.ca.gov
+A5123A,N426DF,Cal Fire,Grumman S-2F 3AT Tracker,S2P,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.fire.ca.gov
+A50E83,N425DF,Cal Fire,Grumman S-2F 3AT Tracker,S2P,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.fire.ca.gov
+A50ACC,N424DF,Cal Fire,Grumman S-2F 3AT Tracker,S2P,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.fire.ca.gov
+A5035E,N422DF,Cal Fire,Grumman S-2F 3AT Tracker,S2P,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.fire.ca.gov
+A59025,N458DF,Cal Fire,Grumman S-2G Tracker,S2P,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.fire.ca.gov
+A568A6,N448DF,Cal Fire,Grumman S-2G Tracker,S2P,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.fire.ca.gov
+A51D5F,N429DF,Cal Fire,North American Rockwell OV-10A Bronco,V10,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.fire.ca.gov
+A4FFA7,N421DF,Cal Fire,North American Rockwell OV-10A Bronco,V10,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.fire.ca.gov
+A4F229,N418DF,Cal Fire,North American Rockwell OV-10A Bronco,V10,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.fire.ca.gov
+A4E704,N415DF,Cal Fire,North American Rockwell OV-10A Bronco,V10,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.fire.ca.gov
+A4E34D,N414DF,Cal Fire,North American Rockwell OV-10A Bronco,V10,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.fire.ca.gov
+A4DF96,N413DF,Cal Fire,North American Rockwell OV-10A Bronco,V10,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.fire.ca.gov
+A4D471,N410DF,Cal Fire,North American Rockwell OV-10A Bronco,V10,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.fire.ca.gov
+A4CE61,N409DF,Cal Fire,North American Rockwell OV-10A Bronco,V10,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.fire.ca.gov
+A4C6F3,N407DF,Cal Fire,North American Rockwell OV-10A Bronco,V10,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.fire.ca.gov
+A4B817,N403DF,Cal Fire,North American Rockwell OV-10A Bronco,V10,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.fire.ca.gov
+A4B460,N402DF,Cal Fire,North American Rockwell OV-10A Bronco,V10,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.fire.ca.gov
+A4B0A9,N401DF,Cal Fire,North American Rockwell OV-10A Bronco,V10,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.fire.ca.gov
+A4ACF2,N400DF,Cal Fire,North American Rockwell OV-10A Bronco,V10,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.fire.ca.gov
+A5C16B,N470DF,Cal Fire,North American Rockwell OV-10D Bronco,V10,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.fire.ca.gov
+A5BB5B,N469DF,Cal Fire,North American Rockwell OV-10D Bronco,V10,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.fire.ca.gov
+A4CAAA,N408DF,Cal Fire,North American Rockwell OV-10D Bronco,V10,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.fire.ca.gov
+A5F40F,N483DF,Cal Fire,Sikorsky S-70i,H60,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.fire.ca.gov
+A0956B,N137CG,Coulson Aviation,Boeing 737,B733,Civ,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.coulsonaviationusa.com
+501F9A,895,Croatian Air Force,Air Tractor AT-802AF,AT8T,Mil,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://w.wiki/4mdB
+501F9F,866,Croatian Air Force,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Croatian_Air_Force
+71C985,HL9185,Daegu Fire Department,Eurocopter AS350 Squirrel B2,AS50,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://tinyurl.com/mw353ct4
+71D446,HL9446,Daegu Fire Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Air Attack,Helix,Aerial Firefighter,https://www.daegu.go.kr/119english/index.do
+71CE49,HL9649,Daegu Fire Dept,AgustaWestland AW.169,A169,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.daegu.go.kr/119english/index.do
+A30FE0,N297EA,Erickson Aero Tanker,McDonnell Douglas DC-9 87,MD87,Civ,Fire Bomber,Air Attack,Wildfire,Aerial Firefighter,http://www.eatanker.com/
+71CE26,HL9626,Gangwon Fire Fighting Dept,AgustaWestland AW.139,A139,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://w.wiki/4mcn
+71CC85,HL9485,Gangwon Fire Fighting Dept,AgustaWestland AW.139,A139,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://w.wiki/4mcn
+71CC76,HL9476,Gangwon Fire Fighting Dept,AgustaWestland AW.139,A139,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://w.wiki/4mcn
+71CE13,HL9613,Gangwon Fire Fighting Dept,Sikorsky S-76 B,S76,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://w.wiki/4mcn
+C06F0D,C-GQBK,Government of Quebec,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.quebec.ca/en
+C06F0B,C-GQBI,Government of Quebec,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.quebec.ca/en
+C06F09,C-GQBG,Government of Quebec,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.quebec.ca/en
+C06F08,C-GQBF,Government of Quebec,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.quebec.ca/en
+C06F07,C-GQBE,Government of Quebec,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.quebec.ca/en
+C06F06,C-GQBD,Government of Quebec,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.quebec.ca/en
+C06F05,C-GQBC,Government of Quebec,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.quebec.ca/en
+C06F03,C-GQBA,Government of Quebec,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.quebec.ca/en
+C0348D,C-FTXK,Government of Quebec,Canadair CL-215,CL2P,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.quebec.ca/en
+C0348C,C-FTXJ,Government of Quebec,Canadair CL-215,CL2P,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.quebec.ca/en
+C03489,C-FTXG,Government of Quebec,Canadair CL-215,CL2P,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.quebec.ca/en
+C0537E,C-GFQB,Government of Quebec,Canadair CL-215,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.quebec.ca/en
+46A0C7,SX-HFG,Greek Fire Dept,Eurocopter AS332 Super Puma,AS32,Gov,Firebird,Air Attack,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Hellenic_Fire_Service
+46A0C6,SX-HFF,Greek Fire Dept,Eurocopter AS332 Super Puma,AS32,Gov,Firebird,Air Attack,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Hellenic_Fire_Service
+46A0C5,SX-HFE,Greek Fire Dept,MBB-Kawasaki BK 117 C-1,BK17,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://w.wiki/4mco
+46A0C4,SX-HFD,Greek Fire Dept,MBB-Kawasaki BK 117 C-1,BK17,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://w.wiki/4mco
+71D456,HL9456,Gyong-Gi Fire Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Air Attack,Helix,Aerial Firefighter,https://119.gg.go.kr/eng/?page_id=447
+AC9AE5,N911FF,Hawaii County Fire Dept,Bell 206L Long Ranger,B06,Gov,Firebird,Air Attack,Wildfire,Aerial Firefighter,https://www.hawaiicounty.gov/departments/fire
+AD2ED1,N949CH,Heligroup Fire,Boeing-Vertol CH-47D Chinook,H47,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://chiaviation.com/about
+AD2B1A,N948CH,Heligroup Fire,Boeing-Vertol CH-47D Chinook,H47,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://chiaviation.com/about
+AD2763,N947CH,Heligroup Fire,Boeing-Vertol CH-47D Chinook,H47,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://chiaviation.com/about
+ACC29C,N921HM,Heligroup Fire,Eurocopter AS350 Squirrel,AS50,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://chiaviation.com/about
+AC8D1E,N908CH,Heligroup Fire,Sikorsky S-61 N,S61,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://chiaviation.com/about
+AC8967,N907CH,Heligroup Fire,Sikorsky S-61 N,S61,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://chiaviation.com/about
+AB456D,N825WL,Heligroup Fire,Sikorsky S-61 N,S61,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://chiaviation.com/about
+71CA77,HL9277,Incheon Fire & Safety Dept,AgustaWestland AW.139,A139,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://w.wiki/4mcn
+71CC08,HL9408,Incheon Fire & Safety Dept,Bell 230,B230,Gov,Wildfire,Air Attack,Airworlf,Aerial Firefighter,https://en.wikipedia.org/wiki/Fire_services_in_South_Korea
+32003E,VF-145,Italian Fire Service,AgustaWestland AW.139,A139,Gov,Air Attack,Firebird,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Vigili_del_Fuoco
+32003D,VF-144,Italian Fire Service,AgustaWestland AW.139,A139,Gov,Air Attack,Firebird,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Vigili_del_Fuoco
+32003C,VF-143,Italian Fire Service,AgustaWestland AW.139,A139,Gov,Air Attack,Firebird,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Vigili_del_Fuoco
+32002D,VF-140,Italian Fire Service,AgustaWestland AW.139,A139,Gov,Air Attack,Firebird,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Vigili_del_Fuoco
+32002C,VF-139,Italian Fire Service,AgustaWestland AW.139,A139,Gov,Air Attack,Firebird,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Vigili_del_Fuoco
+320050,VF-149,Italian Fire Service,AgustaWestland AW.139,A139,Gov,Air Attack,Firebird,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Vigili_del_Fuoco
+320044,VF-147,Italian Fire Service,AgustaWestland AW.139,A139,Gov,Air Attack,Firebird,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Vigili_del_Fuoco
+320037,VF-142,Italian Fire Service,AgustaWestland AW.139,A139,Gov,Air Attack,Firebird,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Vigili_del_Fuoco
+320036,VF-141,Italian Fire Service,AgustaWestland AW.139,A139,Gov,Air Attack,Firebird,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Vigili_del_Fuoco
+320035,VF-84,Italian Fire Service,AW.109E Power,A109,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Vigili_del_Fuoco
+320034,VF-82,Italian Fire Service,AW.109E Power,A109,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Vigili_del_Fuoco
+320033,VF-81,Italian Fire Service,AW.109E Power,A109,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Vigili_del_Fuoco
+320032,VF-80,Italian Fire Service,AW.109E Power,A109,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Vigili_del_Fuoco
+30041D,I-DPCS,Italian Protezione Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Protezione_Civile
+3003B6,I-DPCN,Italian Protezione Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Protezione_Civile
+3002ED,I-DPCR,Italian Protezione Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Protezione_Civile
+30024C,I-DPCH,Italian Protezione Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Protezione_Civile
+30024B,I-DPCG,Italian Protezione Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Protezione_Civile
+30024A,I-DPCF,Italian Protezione Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Protezione_Civile
+30023F,I-DPCO,Italian Protezione Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Protezione_Civile
+30023E,I-DPCE,Italian Protezione Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Protezione_Civile
+30023D,I-DPCD,Italian Protezione Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Protezione_Civile
+300337,I-DPCC,Italian Protezione Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Protezione_Civile
+300248,I-DPCZ,Italian Protezione Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Protezione_Civile
+300245,I-DPCW,Italian Protezione Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Protezione_Civile
+300244,I-DPCV,Italian Protezione Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Protezione_Civile
+300243,I-DPCU,Italian Protezione Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Protezione_Civile
+300242,I-DPCT,Italian Protezione Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Protezione_Civile
+300241,I-DPCQ,Italian Protezione Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Protezione_Civile
+300240,I-DPCP,Italian Protezione Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Protezione_Civile
+71CE33,HL9633,Jeju Fire Safety Division,KAI KUH-1 Surion EM,SURN,Gov,Flying Fire Extinguisher,Air Attack,Fire Festival,Aerial Firefighter,https://www.visitjeju.net/u/5QH
+AC9B1B,N911HK,Kaui Fire Department,MD 369FF,H500,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.kauai.gov/Fire
+845BF6,JA10KC,Kitakyushu Fire Dept,AS365 N3 Dauphin,AS65,Gov,Firebird,Air Attack,Wildfire,Aerial Firefighter,https://www.city.kitakyushu.lg.jp/shoubou/shoubou.html
+71CC37,HL9437,Korea Forestry Department,Kamov Ka-32 A,KA27,Civ,Double Vision,Air Attack,Helix,Aerial Firefighter,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
+71CC20,HL9420,Korea Forestry Department,Kamov Ka-32 A,KA27,Civ,Double Vision,Air Attack,Helix,Aerial Firefighter,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
+71D426,HL9426,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Air Attack,Helix,Aerial Firefighter,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
+71D412,HL9412,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Air Attack,Helix,Aerial Firefighter,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
+71D411,HL9411,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Air Attack,Helix,Aerial Firefighter,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
+71D410,HL9410,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Air Attack,Helix,Aerial Firefighter,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
+71D409,HL9409,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Air Attack,Helix,Aerial Firefighter,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
+71CC36,HL9436,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Air Attack,Helix,Aerial Firefighter,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
+71CC35,HL9435,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Air Attack,Helix,Aerial Firefighter,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
+71CC34,HL9434,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Air Attack,Helix,Aerial Firefighter,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
+71CC33,HL9433,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Air Attack,Helix,Aerial Firefighter,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
+71CC32,HL9432,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Air Attack,Helix,Aerial Firefighter,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
+71CC31,HL9431,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Air Attack,Helix,Aerial Firefighter,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
+71CC30,HL9430,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Air Attack,Helix,Aerial Firefighter,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
+71CC29,HL9429,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Air Attack,Helix,Aerial Firefighter,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
+71CC28,HL9428,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Air Attack,Helix,Aerial Firefighter,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
+71CC27,HL9427,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Air Attack,Helix,Aerial Firefighter,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
+71CC25,HL9425,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Air Attack,Helix,Aerial Firefighter,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
+71CC24,HL9424,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Air Attack,Helix,Aerial Firefighter,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
+71CC23,HL9423,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Air Attack,Helix,Aerial Firefighter,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
+71CC22,HL9422,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Air Attack,Helix,Aerial Firefighter,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
+71CC21,HL9421,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Air Attack,Helix,Aerial Firefighter,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
+71CC18,HL9418,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Air Attack,Helix,Aerial Firefighter,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
+71CC17,HL9417,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Air Attack,Helix,Aerial Firefighter,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
+71CC16,HL9416,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Air Attack,Helix,Aerial Firefighter,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
+71CC15,HL9415,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Air Attack,Helix,Aerial Firefighter,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
+71CC14,HL9414,Korea Forestry Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Air Attack,Helix,Aerial Firefighter,https://english.forest.go.kr/kfsweb/kfs/subIdx/Index.do?mn=UENG
+8408F7,JA02FD,Kyoto City Fire Dept,AS365 N3 Dauphin,AS65,Gov,Firebird,Air Attack,Wildfire,Aerial Firefighter,https://www.city.kyoto.lg.jp/shobo/page/0000002888.html
+71D462,HL9462,Kyungbuk Fire Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Air Attack,Helix,Aerial Firefighter,https://en.wikipedia.org/wiki/Fire_services_in_South_Korea
+A33266,N305FD,Los Angeles Fire Department,AgustaWestland AW.139,A139,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.lafd.org
+A32EAF,N304FD,Los Angeles Fire Department,AgustaWestland AW.139,A139,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.lafd.org
+A32AF8,N303FD,Los Angeles Fire Department,AgustaWestland AW.139,A139,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.lafd.org
+A32741,N302FD,Los Angeles Fire Department,AgustaWestland AW.139,A139,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.lafd.org
+A3238A,N301FD,Los Angeles Fire Department,AgustaWestland AW.139,A139,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.lafd.org
+A3361D,N306FD,Los Angeles Fire Department,Bell 206B Jet Ranger,B06,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.lafd.org
+A117CF,N17LA,Los Angeles Fire Department,Bell 412EP,B412,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.lafd.org
+A054AD,N120LA,Los Angeles Fire Department,Bell 412EP,B412,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.lafd.org
+A0A152,N14LA,Los Angeles Fire Department,Bell 412EP,B412,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.lafd.org
+A13F4E,N18LA,Los Angeles Fire Department,Bell 412HP,B412,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.lafd.org
+A9F008,N73985,Los Angeles Fire Department,Bell 47G-3B-1,B47G,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.lafd.org
+AB358D,N821LA,Los Angeles Fire Department,Sikorsky S-70,H60,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.lafd.org
+A16926,N190LA,Los Angeles Fire Department,Sikorsky S-70A,H60,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.lafd.org
+A0F2A9,N160LA,Los Angeles Fire Department,Sikorsky S-70A,H60,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.lafd.org
+A0C8D1,N15LA,Los Angeles Fire Department,Sikorsky S-70A,H60,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.lafd.org
+AB3944,N822LA,Los Angeles Fire Department,Sikorsky S-70i,H60,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.lafd.org
+C07044,C-GQNJ,Mag Aerospace,B200 Super King Air,BE20,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,http://www.magaero.ca
+C05D93,C-GJLI,Mag Aerospace,B200 Super King Air,BE20,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,http://www.magaero.ca
+C01B5B,C-FKJI,Mag Aerospace,B200 Super King Air,BE20,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,http://www.magaero.ca
+C07927,C-GTWW,Mag Aerospace,C90 King Air,BE9L,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,http://www.magaero.ca
+750476,9M-BOF,Malaysia Fire & Rescue Dept,AgustaWestland AW.189,A189,Gov,Firebird,Air Attack,Wildfire,Aerial Firefighter,https://tinyurl.com/2p8jab29
+750442,9M-BOE,Malaysia Fire & Rescue Dept,AgustaWestland AW.189,A189,Gov,Firebird,Air Attack,Wildfire,Aerial Firefighter,https://tinyurl.com/2p8jab29
+A1D480,N217LC,Miami Dade Fire & Rescue,AgustaWestland AW.139,A139,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://tinyurl.com/2t4kjxez
+A1B0B8,N208LC,Miami Dade Fire & Rescue,AgustaWestland AW.139,A139,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://tinyurl.com/2t4kjxez
+AC9AE3,N911FD,Miami Dade Fire & Rescue,Bell 412EP,B412,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.miamidade.gov/global/fire/home.page
+AC9A72,N911AR,Miami Dade Fire & Rescue,Bell 412EP,B412,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.miamidade.gov/global/fire/home.page
+A2237E,N237LC,Miami Dade Fire & Rescue,Bell 412EP,B412,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.miamidade.gov/global/fire/home.page
+A21FC7,N236LC,Miami Dade Fire & Rescue,Bell 412EP,B412,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.miamidade.gov/global/fire/home.page
+733470,EP-MCP,National Fire Service,Tupolev Tu-154M,T154,Gov,Firebird,Air Attack,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Russian_State_Fire_Service
+A0110E,N103NJ,New Jersey Forest Fire Service,Bell 206B Jet Ranger,B06,Gov,Firebird,Air Attack,Wildfire,Aerial Firefighter,https://www.nj.gov/dep/parksandforests/fire
+A00D57,N102NJ,New Jersey Forest Fire Service,Bell 206B Jet Ranger,B06,Gov,Firebird,Air Attack,Wildfire,Aerial Firefighter,https://www.nj.gov/dep/parksandforests/fire
+A01C33,N106NJ,New Jersey Forest Fire Service,Bell UH-1H Iroquois,UH1,Gov,Firebird,Air Attack,Wildfire,Aerial Firefighter,https://www.nj.gov/dep/parksandforests/fire
+A0187C,N105NJ,New Jersey Forest Fire Service,Bell UH-1H Iroquois,UH1,Gov,Firebird,Air Attack,Wildfire,Aerial Firefighter,https://www.nj.gov/dep/parksandforests/fire
+7C6B99,VH-VJF,NSW Rural Fire Service,Bell 412EP,B412,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.rfs.nsw.gov.au
+7C6B97,VH-VJD,NSW Rural Fire Service,Bell 412EP,B412,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.rfs.nsw.gov.au
+A72ADA,N561CG,NSW Rural Fire Service,Cessna Citation V,C560,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.rfs.nsw.gov.au
+C06A56,C-GOGZ,Ontario MNR Aviation Service,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.ontario.ca/page/aviation-services
+C06A55,C-GOGY,Ontario MNR Aviation Service,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.ontario.ca/page/aviation-services
+C06A54,C-GOGX,Ontario MNR Aviation Service,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.ontario.ca/page/aviation-services
+C06A53,C-GOGW,Ontario MNR Aviation Service,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.ontario.ca/page/aviation-services
+C06A44,C-GOGH,Ontario MNR Aviation Service,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.ontario.ca/page/aviation-services
+C06A43,C-GOGG,Ontario MNR Aviation Service,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.ontario.ca/page/aviation-services
+C06A42,C-GOGF,Ontario MNR Aviation Service,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.ontario.ca/page/aviation-services
+C06A41,C-GOGE,Ontario MNR Aviation Service,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.ontario.ca/page/aviation-services
+C06A40,C-GOGD,Ontario MNR Aviation Service,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.ontario.ca/page/aviation-services
+C041A7,C-FYWK,Province of Newfoundland,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.gov.nl.ca
+C02583,C-FOFI,Province of Newfoundland,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.gov.nl.ca
+C02341,C-FNJC,Province of Newfoundland,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.gov.nl.ca
+C015C6,C-FIGJ,Province of Newfoundland,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.gov.nl.ca
+C04D58,C-GDHN,Province of Northwest Territories,Canadair CL-215,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.gov.nt.ca
+C04BDC,C-GCSX,Province of Northwest Territories,Canadair CL-215,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.gov.nt.ca
+C049D1,C-GBYU,Province of Northwest Territories,Canadair CL-215,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.gov.nt.ca
+C048D6,C-GBPD,Province of Northwest Territories,Canadair CL-215,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.gov.nt.ca
+C041BD,C-FYXG,Province of Saskatchewan,Canadair CL-215,CL2P,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.saskatchewan.ca
+C041AB,C-FYWO,Province of Saskatchewan,Canadair CL-215,CL2P,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.saskatchewan.ca
+C028B7,C-FPKW,Province of Saskatchewan,Canadair CL-215,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.saskatchewan.ca
+C00091,C-FAFO,Province of Saskatchewan,Canadair CL-215,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.saskatchewan.ca
+02010A,CN-ATQ,Royal Moroccan Air Force,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Fire,Aerial Firefighter,https://en.wikipedia.org/wiki/Royal_Moroccan_Air_Force
+0200EE,CN-ATN,Royal Moroccan Air Force,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Fire,Aerial Firefighter,https://en.wikipedia.org/wiki/Royal_Moroccan_Air_Force
+0200E6,CN-ATM,Royal Moroccan Air Force,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Fire,Aerial Firefighter,https://en.wikipedia.org/wiki/Royal_Moroccan_Air_Force
+020109,CN-ATP,Royal Moroccan Air Force,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Fire,Aerial Firefighter,https://en.wikipedia.org/wiki/Royal_Moroccan_Air_Force
+020107,CN-ATO,Royal Moroccan Air Force,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Fire,Aerial Firefighter,https://en.wikipedia.org/wiki/Royal_Moroccan_Air_Force
+A042FE,N116FD,Sacramento Metropolitan Fire District,Bell UH-1H Iroquois,UH1,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://metrofire.ca.gov
+A03F47,N115FD,Sacramento Metropolitan Fire District,Bell UH-1H Iroquois,UH1,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://metrofire.ca.gov
+A2D346,N281SD,San Diego City Fire Dept,Bell 212,B212,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.sandiego.gov/fire
+A2D6FD,N282SD,San Diego City Fire Dept,Bell 412EP,B412,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.sandiego.gov/fire
+A2DAB4,N283SD,San Diego City Fire Dept,Sikorsky S-70,H60,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.sandiego.gov/fire
+A1A588,N205KS,Santa Barbara County Fire Department,Bell UH-1H Iroquois,UH1,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.sbcfire.com
+AD6C94,N964SB,Santa Barbara County Fire Department,Sikorsky HH-60L Blackhawk,H60,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.sbcfire.com
+3B7B65,F-ZBFJ,Securite Civile,B200 Super King Air,BE20,Gov,Water Bomber Group,Air Attack,Wildfire,Aerial Firefighter,https://w.wiki/4nsA
+3B7B76,F-ZBFY,Securite Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://w.wiki/4nsA
+3B7B75,F-ZBFV,Securite Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://w.wiki/4nsA
+3B7B74,F-ZBFW,Securite Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://w.wiki/4nsA
+3B7B73,F-ZBEG,Securite Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://w.wiki/4nsA
+3B7B72,F-ZBEU,Securite Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://w.wiki/4nsA
+3B7B71,F-ZBME,Securite Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://w.wiki/4nsA
+3B7B70,F-ZBMF,Securite Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://w.wiki/4nsA
+3B7B6F,F-ZBFP,Securite Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://w.wiki/4nsA
+3B7B6E,F-ZBFS,Securite Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://w.wiki/4nsA
+3B7B6D,F-ZBFN,Securite Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://w.wiki/4nsA
+3B7B6C,F-ZBFX,Securite Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://w.wiki/4nsA
+3B7B6B,F-ZBMG,Securite Civile,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://w.wiki/4nsA
+3B7B3F,F-ZBMI,Securite Civile,DHC-8-400 MR,DH8D,Gov,Multi Role,Air Attack,Wildfire,Aerial Firefighter,https://w.wiki/4nsA
+C06DC8,C-GPOX,Securite Civile,DHC-8-402,DH8D,Gov,Multi Role,Air Attack,Wildfire,Aerial Firefighter,https://w.wiki/4nsA
+3B7B86,F-ZBMC,Securite Civile,DHC-8-402,DH8D,Gov,Multi Role,Air Attack,Wildfire,Aerial Firefighter,https://w.wiki/4nsA
+3B7B63,F-ZBMH,Securite Civile,DHC-8-402,DH8D,Gov,Multi Role,Air Attack,Wildfire,Aerial Firefighter,https://w.wiki/4nsA
+3B7B90,F-ZBQA,Securite Civile,Eurocopter EC145,EC45,Gov,Search And Rescue,Air Attack,EMS,Aerial Firefighter,https://w.wiki/4nsA
+3B7B9A,F-ZBPQ,Securite Civile,Eurocopter EC145,EC45,Gov,Search And Rescue,Air Attack,EMS,Aerial Firefighter,https://w.wiki/4nsA
+3B7B98,F-ZBPS,Securite Civile,Eurocopter EC145,EC45,Gov,Search And Rescue,Air Attack,EMS,Aerial Firefighter,https://w.wiki/4nsA
+3B7BA2,F-ZBPI,Securite Civile,Eurocopter EC145,EC45,Gov,Search And Rescue,Air Attack,EMS,Aerial Firefighter,https://w.wiki/4nsA
+71CC48,HL9448,Seoul Metro Fire & Disaster Dept,AS365 Dauphin,AS65,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://fire.seoul.go.kr/english
+71CC47,HL9447,Seoul Metro Fire & Disaster Dept,AS365 Dauphin,AS65,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://fire.seoul.go.kr/english
+71CE39,HL9639,Seoul Metro Fire & Disaster Dept,AW.189,A189,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://fire.seoul.go.kr/english
+0093C4,ZS-HLZ,South African Fire Fighting Association,Bell UH-1H Iroquois,UH1,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.fpasa.co.za
+0093C2,ZS-HLX,South African Fire Fighting Association,Bell UH-1H Iroquois,UH1,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.fpasa.co.za
+0093B5,ZS-HLK,South African Fire Fighting Association,Bell UH-1H Iroquois,UH1,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.fpasa.co.za
+0093AB,ZS-HLA,South African Fire Fighting Association,Bell UH-1H Iroquois,UH1,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.fpasa.co.za
+71D486,HL9486,South Korean National Park Authority,Kamov Ka-32 A,KA27,Civ,Double Vision,Air Attack,Helix,Aerial Firefighter,https://english.knps.or.kr
+71D481,HL9481,South Korean National Park Authority,Kamov Ka-32 A,KA27,Civ,Double Vision,Air Attack,Helix,Aerial Firefighter,https://english.knps.or.kr
+71D465,HL9465,South Korean National Park Authority,Kamov Ka-32 T,KA27,Civ,Double Vision,Air Attack,Helix,Aerial Firefighter,https://english.knps.or.kr
+354641,UD.14-03,Spanish Air Force,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Spanish_Air_Force
+353042,UD.14-02,Spanish Air Force,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Spanish_Air_Force
+353041,UD.14-01,Spanish Air Force,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Spanish_Air_Force
+344609,UD.14-04,Spanish Air Force,Bombardier CL-415 T,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Spanish_Air_Force
+3464D9,EC-NKY,Titan Firefighting,Air Tractor AT-802,AT8T,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://titanfirefighting.com/en/home
+34634A,EC-NDU,Titan Firefighting,Air Tractor AT-802,AT8T,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://titanfirefighting.com/en/home
+845E9C,JA119E,Tokyo Fire Department,AS365 N3 Dauphin,AS65,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://w.wiki/4mcq
+8623D6,JA62HC,Tokyo Fire Department,Eurocopter EC225 LP,EC25,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://w.wiki/4mcq
+845EAE,JA119Y,Tokyo Fire Department,Eurocopter EC225 LP,EC35,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://w.wiki/4mcq
+846B07,JA14TD,Tokyo Fire Dept,AgustaWestland AW.139,A139,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://w.wiki/4mcq
+85209F,JA35AR,Tokyo Fire Dept,AgustaWestland AW.169,A169,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://w.wiki/4mcq
+84C3DD,JA24HB,Tokyo Fire Dept,AgustaWestland AW.189,A189,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://w.wiki/4mcq
+4BD16D,TC-TKM,Turkish Air Force,Canadair CL-215,CL2P,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.hvkk.tsk.tr
+4BD16C,TC-TKL,Turkish Air Force,Canadair CL-215,CL2P,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.hvkk.tsk.tr
+4BD16B,TC-TKK,Turkish Air Force,Canadair CL-215,CL2P,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.hvkk.tsk.tr
+4BD16A,TC-TKJ,Turkish Air Force,Canadair CL-215,CL2P,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.hvkk.tsk.tr
+4BD168,TC-TKH,Turkish Air Force,Canadair CL-215,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.hvkk.tsk.tr
+4BD17A,TC-TKZ,Turkish Department of Forestation,Canadair CL-215,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.tarimorman.gov.tr/
+4BD179,TC-TKY,Turkish Department of Forestation,Canadair CL-215,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.tarimorman.gov.tr/
+4BD176,TC-TKV,Turkish Department of Forestation,Canadair CL-215,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.tarimorman.gov.tr/
+4BD174,TC-TKT,Turkish Department of Forestation,Canadair CL-215,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.tarimorman.gov.tr/
+71D407,HL9407,Ulsan Fire Department,Kamov Ka-32 T,KA27,Civ,Double Vision,Air Attack,Helix,Aerial Firefighter,https://en.wikipedia.org/wiki/Fire_services_in_South_Korea
+A1A4B7,N205BH,Ventura County Fire Department,Bell EH-1H Iroquois,UH1,Civ,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://vcfd.org
+A95413,N70VC,Ventura County Fire Department,Sikorsky HH-60L Blackhawk,H60,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://vcfd.org
+A7C6C4,N60VC,Ventura County Fire Department,Sikorsky HH-60L Blackhawk,H60,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://vcfd.org
+C03194,C-FSUD,Ventura County Fire Department,Turbo Commander 690B,AC90,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,http://www.magaero.ca
+AAE162,N80VC,Ventura County Fire Department,UH-60L Blackhawk,H60,Civ,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://vcfd.org
 43C39B,ZJ782,Army Air Corps,Eurocopter AS365 N2 Dauphin,AS65,Mil,Special Ops,Special Air Service,22 SAS,Special Forces,https://en.wikipedia.org/wiki/No._658_Squadron_AAC
 43C39A,ZJ781,Army Air Corps,Eurocopter AS365 N2 Dauphin,AS65,Mil,Special Ops,Special Air Service,22 SAS,Special Forces,https://en.wikipedia.org/wiki/No._658_Squadron_AAC
 43C399,ZJ780,Army Air Corps,Eurocopter AS365 N2 Dauphin,AS65,Mil,Special Ops,Special Air Service,22 SAS,Special Forces,https://en.wikipedia.org/wiki/No._658_Squadron_AAC
@@ -12670,7 +12670,7 @@ A660F6,N51VE,LoveFrom Inc,Gulfstream G500,GLF5,Gov,Jony Ive,LoveFrom,Vanity Plat
 403A81,G-YELL,Private,Murphy Aircraft Murphy Rebel,RBEL,Civ,Midgnight Hour,More More More,Vanity Plate,Vanity Plate,https://youtu.be/VdphvuyaV_I
 43EAE1,M-ETAL,Private,Piaggio P-180 Avanti II,P180,Civ,These Go To Eleven,Sonorous,Vanity Plate,Vanity Plate,https://youtu.be/uMSV4OteqBE
 43ED5F,2-FUNN,Private,Piper PA-32 R,PA32,Civ,Till Your Daddy Take Your TBird Away,Cant Have Enough,Vanity Plate,Vanity Plate,https://youtu.be/PIb6AZdTr-A
-3D9963,D-GEIL,Private,Piper PA-34-220T Seneca V,PA34,Civ,Hot Hot Hot Hot,Fire,Vanity Plate,Vanity Plate,https://youtu.be/wpK-rgxXvHU
+3D9963,D-GEIL,Private,Piper PA-34-220T Seneca V,PA34,Civ,Air Attack,Fire,Vanity Plate,Vanity Plate,https://youtu.be/wpK-rgxXvHU
 3EC25F,D-KOOL,Private,Schleicher ASH 25,AS25,Civ,Boney M,Where Is The Engine,Vanity Plate,Vanity Plate,https://youtu.be/QtxlCsVKkvY
 43E75E,M-ONTY,Private,Sikorsky S-76 C,S76,Civ,Python,Mole,Vanity Plate,Vanity Plate,http://torinak.com/qaop#!montymole3
 3D069D,D-EATH,Private Owner,Piper PA-28 Cherokee,P28A,Civ,Wheelbarrow,Jesus He Knows Me,Vanity Plate,Vanity Plate,https://en.wikipedia.org/wiki/Death_(Discworld)
@@ -13117,12 +13117,12 @@ A69181,N522MT,Aerocare,Bell 407,B407,Civ,Air Ambo,Medical Evac,Saving Lives,Flyi
 AC9B67,N911LL,Aerocare,Bell 407,B407,Civ,Air Ambo,Medical Evac,Saving Lives,Flying Doctors,https://www.helis.com/database/sqd/AeroCare-Texas/
 A51E5B,N429PH,PHI Air Medical,Bell 407,B407,Civ,Air Ambo,Medical Evac,Saving Lives,Flying Doctors,https://www.helis.com/database/sqd/Air-Med-12-CHI-St-Joseph/
 A53347,N434PH,PHI Air Medical,Bell 407,B407,Civ,Air Ambo,Medical Evac,Saving Lives,Flying Doctors,https://www.helis.com/database/sqd/Air-Med-12-CHI-St-Joseph/
-A502F5,N4219M,Bombero Aviation LLC,Air Tractor AT-802A,AT8T,Civ,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Air_Tractor_AT-802
-A399B0,N331BS,B & S Air Inc,Air Tractor AT-802A,AT8T,Civ,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Air_Tractor_AT-802
-A0DCD6,N155AV,Teton Leasing LLC,Beechcraft Super King Air 200,BE20,Civ,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Beechcraft_Super_King_Air
-A4F203,N418BT,Bridger Air Tanker 3 LLC,Canadair CL-215T,CL2T,Civ,Flying Fire Extinguisher,Super Scooper,Aerial Firefighter,Sam Tân,https://en.wikipedia.org/wiki/Canadair_CL-215
-A50338,N422BT,Bridger Air Tanker 6 LLC,Canadair CL-215T,CL2T,Civ,Flying Fire Extinguisher,Super Scooper,Aerial Firefighter,Sam Tân,https://en.wikipedia.org/wiki/Canadair_CL-215
-A7C4E6,N60A,5-State Helicopters Inc,Sikorsky UH-60A Black Hawk,UH60,Civ,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Sikorsky_UH-60_Black_Hawk
+A502F5,N4219M,Bombero Aviation LLC,Air Tractor AT-802A,AT8T,Civ,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Air_Tractor_AT-802
+A399B0,N331BS,B & S Air Inc,Air Tractor AT-802A,AT8T,Civ,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Air_Tractor_AT-802
+A0DCD6,N155AV,Teton Leasing LLC,Beechcraft Super King Air 200,BE20,Civ,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Beechcraft_Super_King_Air
+A4F203,N418BT,Bridger Air Tanker 3 LLC,Canadair CL-215T,CL2T,Civ,Flying Fire Extinguisher,Super Scooper,Air Attack,Aerial Firefighter,https://en.wikipedia.org/wiki/Canadair_CL-215
+A50338,N422BT,Bridger Air Tanker 6 LLC,Canadair CL-215T,CL2T,Civ,Flying Fire Extinguisher,Super Scooper,Air Attack,Aerial Firefighter,https://en.wikipedia.org/wiki/Canadair_CL-215
+A7C4E6,N60A,5-State Helicopters Inc,Sikorsky UH-60A Black Hawk,UH60,Civ,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Sikorsky_UH-60_Black_Hawk
 A1DCB0,N219TX,Texas Department of Public Safety,Pilatus PC-12,PC12,Pol,Police Squad,Spectre 219,Speed Enforced by Aircraft,Police Forces,https://en.wikipedia.org/wiki/Pilatus_PC-12
 A0644D,N124TX,Texas Department of Public Safety,Eurocopter AS350 Squirrel B2,AS50,Pol,Police Squad,Spectre 219,Speed Enforced by Aircraft,Police Forces,https://w.wiki/7kcW
 A00557,N100GN,Fertitta Entertainment Holdings LLC,Airbus Helicopters EC-155 B1,EC55,Civ,BizJet,Gambler,Entertainent,As Seen on TV,https://en.wikipedia.org/wiki/Eurocopter_EC135
@@ -13168,23 +13168,23 @@ A5C292,N470RA,Rocky Mountian Holdings LLC,Bell 407,B407,Civ,Air Ambo,Medical Eva
 A5CDB7,N473RA,Air Methods Corp,Bell 407,B407,Civ,Air Ambo,Medical Evac,Saving Lives,Flying Doctors,https://www.airmethods.com/
 A6804C,N518MT,Pacific Western Bank,Bell 407,B407,Civ,Air Ambo,Medical Evac,Saving Lives,Flying Doctors,https://www.med-trans.net/
 A2CCA7,N28LL,News Helicopter,Bell 407,B407,Civ,Eye In The Sky,Breaking News,News Chopper,As Seen on TV,https://flyhelicoptersinc.com/
-A0F04B,N16KW,Wild Blue Aviation LLC,Beechcraft King Air C90A,BE9L,Civ,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Beechcraft_King_Air
-A179F0,N1944E,Choice Aviation LLC,Cessna 340 Super,C340,Civ,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://choiceaviation.com/
-A4ACFD,N400DS,Flying H Enterprises LLC,Commander 690/840,AC90,Civ,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Aero_Commander_500_family
-A808BC,N61698,Wildfire Aviation LLC,Beechcraft King Air C90A,BE9L,Civ,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Beechcraft_King_Air
-AA1DE9,N751BR,RV Aviation LLC,Commander 690/840,AC90,Civ,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Aero_Commander_500_family
-AA75C0,N773SD,South Dakota Department of Transportation,Beechcraft King Air C90A,BE9L,Civ,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://dot.sd.gov/
-A22E59,N24HD,Tenax Aerospace LLC,Beech 200 Super King Air,BE20,Civ,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://tenaxaerospace.com/
-A63543,N5AE,Tenax Aerospace LLC,Beech 200 Super King Air,BE20,Civ,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://tenaxaerospace.com/
-A18DD6,N2FH,Brainerd Helicopters Inc,Sikorsky UH-60 Black Hawk,H60,Civ,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,http://brainerdhelicopters.com/
-A8B4C7,N660FS,Endless Summer Aviation LLC,Sikorsky UH-60 Black Hawk,H60,Civ,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Sikorsky_UH-60_Black_Hawk
-AB2EA3,N82BH,Jambb LLC,Sikorsky UH-60 Black Hawk,H60,Civ,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Sikorsky_UH-60_Black_Hawk
-AD80D4,N9696W,Croman Corp,Sikorsky Sea King,S61,Civ,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://croman.net/
-AD84BA,N970MB,Sky High Leasing LLC,Kaman K-1200 K-Max,KMAX,Civ,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://croman.net/
-A50DDC,N4247V,Midwest Truxton International Inc,Sikorsky S-58T,S58T,Civ,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://midwesthelicopters.com/home/
-AD9330,N974H,Hillcrest Aircraft Co Inc,Bell 407,B407,Civ,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://www.hillcrestaircraft.com/
-A1801F,N196TA,Helo N426HA LLC,Bell 407,B407,Civ,Flying Fire Extinguisher,Aerial Firefighter,Wildfire,Sam Tân,https://en.wikipedia.org/wiki/Bell_407
-A3E916,N351FW,US Fish and Wildlife Service,Eurocopter Squirrel AS.350 B2,AS50,Gov,Flying Fire Extinguisher,Wildfire,Air Attack,Aerial Firefighter,https://fws.gov/
+A0F04B,N16KW,Wild Blue Aviation LLC,Beechcraft King Air C90A,BE9L,Civ,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Beechcraft_King_Air
+A179F0,N1944E,Choice Aviation LLC,Cessna 340 Super,C340,Civ,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://choiceaviation.com/
+A4ACFD,N400DS,Flying H Enterprises LLC,Commander 690/840,AC90,Civ,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Aero_Commander_500_family
+A808BC,N61698,Wildfire Aviation LLC,Beechcraft King Air C90A,BE9L,Civ,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Beechcraft_King_Air
+AA1DE9,N751BR,RV Aviation LLC,Commander 690/840,AC90,Civ,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Aero_Commander_500_family
+AA75C0,N773SD,South Dakota Department of Transportation,Beechcraft King Air C90A,BE9L,Civ,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://dot.sd.gov/
+A22E59,N24HD,Tenax Aerospace LLC,Beech 200 Super King Air,BE20,Civ,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://tenaxaerospace.com/
+A63543,N5AE,Tenax Aerospace LLC,Beech 200 Super King Air,BE20,Civ,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://tenaxaerospace.com/
+A18DD6,N2FH,Brainerd Helicopters Inc,Sikorsky UH-60 Black Hawk,H60,Civ,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,http://brainerdhelicopters.com/
+A8B4C7,N660FS,Endless Summer Aviation LLC,Sikorsky UH-60 Black Hawk,H60,Civ,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Sikorsky_UH-60_Black_Hawk
+AB2EA3,N82BH,Jambb LLC,Sikorsky UH-60 Black Hawk,H60,Civ,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Sikorsky_UH-60_Black_Hawk
+AD80D4,N9696W,Croman Corp,Sikorsky Sea King,S61,Civ,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://croman.net/
+AD84BA,N970MB,Sky High Leasing LLC,Kaman K-1200 K-Max,KMAX,Civ,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://croman.net/
+A50DDC,N4247V,Midwest Truxton International Inc,Sikorsky S-58T,S58T,Civ,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://midwesthelicopters.com/home/
+AD9330,N974H,Hillcrest Aircraft Co Inc,Bell 407,B407,Civ,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://www.hillcrestaircraft.com/
+A1801F,N196TA,Helo N426HA LLC,Bell 407,B407,Civ,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Bell_407
+A3E916,N351FW,US Fish and Wildlife Service,Eurocopter Squirrel AS.350 B2,AS50,Gov,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://fws.gov/
 AE1C1B,06-08027,United States Army,Boeing-Vertol CH-47F Chinook,H47,Mil,Choppa,Wocka Wocka,Twin Rotor,Toy Soldiers,https://en.wikipedia.org/wiki/Boeing_CH-47_Chinook
 AE5238,07-08034,United States Army,Boeing-Vertol CH-47F Chinook,H47,Mil,Choppa,Wocka Wocka,Twin Rotor,Toy Soldiers,https://en.wikipedia.org/wiki/Boeing_CH-47_Chinook
 AE5251,07-08738,United States Army,Boeing-Vertol CH-47F Chinook,H47,Mil,Choppa,Wocka Wocka,Twin Rotor,Toy Soldiers,https://en.wikipedia.org/wiki/Boeing_CH-47_Chinook
@@ -13432,7 +13432,7 @@ AE14C7,161070,United States Navy,Beech T-44A Pegasus,BE9L,Mil,Advanced Turbo Tra
 AE14C8,161071,United States Navy,Beech T-44A Pegasus,BE9L,Mil,Advanced Turbo Trainer,L-Plate,Bicycle Made for Several,United States Navy,https://w.wiki/7op8
 AE14C9,161072,United States Navy,Beech T-44A Pegasus,BE9L,Mil,Advanced Turbo Trainer,L-Plate,Bicycle Made for Several,United States Navy,https://w.wiki/7op8
 AE14CD,161076,United States Navy,Beech T-44A Pegasus,BE9L,Mil,Advanced Turbo Trainer,L-Plate,Bicycle Made for Several,United States Navy,https://w.wiki/7op8
-A5CD6C,N473NA,Neptune Aviation Services,BAe 146-200 A,B462,Civ,Flying Fire Extinguisher,Wildfire,Air Attack,Aerial Firefighter,https://neptuneaviation.com
+A5CD6C,N473NA,Neptune Aviation Services,BAe 146-200 A,B462,Civ,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://neptuneaviation.com
 A54973,N44NC,Ponderosa Aviation,Rockwell Turbo Commander 690B,AC90,Civ,Air Attack,Wildfire,Lead Plane,Aerial Firefighter,https://w.wiki/7r3o
 A5E9ED,N480PQ,Plaquemines Parish Sheriff's Office,Enstrom 480 B,EN48,Pol,Police Squad,The Cops,Ghetto Bird,Police Forces,https://w.wiki/7r3v
 AC9B1C,N911HL,Jefferson Parish Sheriff's Office,Bell 407,B407,Pol,Police Squad,The Cops,Ghetto Bird,Police Forces,https://w.wiki/7r3t


### PR DESCRIPTION
## Describe your changes

Firefighting overhaul
* Category `Sam Tân` removed in favor of `Aerial Firefighter`
* `Hot Hot Hot` and `Hot Hot Hot Hot` tags replaced
* Rearranged tags where `Aerial Firefighter` would appear twice
* Added `Air Attack` or `Wildfire` where necessary
* Made sure DC-10s weren't listed as Super Scoopers, this is apparently very important to me

I made an attempt to ensure tags wouldn't appear twice (regex search in VS Code) and I think I got it. Does need a second pair of eyes because **you know Dziban**

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] While waiting for someone to review your request, please help review [another open pull request](https://github.com/sdr-enthusiasts/plane-alert-db/pulls) to support the maintainers.
