### PR TITLE
Replace incorrect image for N46E/A597A6

### DIFF
--- a/plane_images.csv
+++ b/plane_images.csv
@@ -766,7 +766,7 @@ A9E51E,https://cdn.jetphotos.com/full/6/83419_1638695216.jpg,https://cdn.jetphot
 424772,https://cdn.jetphotos.com/full/6/92749_1643898987.jpg,https://cdn.jetphotos.com/full/6/46476_1639998828.jpg,https://cdn.jetphotos.com/full/5/20017_1633480110.jpg,
 A45B6C,https://cdn.jetphotos.com/full/5/25309_1526082567.jpg,https://cdn.airplane-pictures.net/images/uploaded-images/2021/4/14/1387352.jpg,,
 A64180,https://cdn.jetphotos.com/full/6/38527_1638530720.jpg,https://cdn.jetphotos.com/full/6/82177_1634312253.jpg,https://cdn.jetphotos.com/full/6/41938_1628510686.jpg,
-A597A6,https://cdn.jetphotos.com/full/5/27903_1598724412.jpg,https://cdn.jetphotos.com/full/5/14991_1452092555.jpg,https://cdn.jetphotos.com/full/6/24303_1430579556.jpg,
+A597A6,https://cdn.jetphotos.com/full/5/27903_1598724412.jpg,https://cdn.jetphotos.com/full/5/14991_1452092555.jpg,https://cdn.jetphotos.com/full/1/81463_1151459930.jpg,
 71C290,https://cdn.jetphotos.com/full/5/88791_1638569334.jpg,https://cdn.jetphotos.com/full/5/96016_1637174832.jpg,https://cdn.jetphotos.com/full/6/32028_1631716135.jpg,
 424276,https://cdn.jetphotos.com/full/6/30399_1643139449.jpg,https://cdn.jetphotos.com/full/6/41100_1641035360.jpg,https://cdn.jetphotos.com/full/6/73844_1635275442.jpg,
 4D209F,https://cdn.jetphotos.com/full/5/34553_1642012193.jpg,https://cdn.jetphotos.com/full/5/45810_1637284922.jpg,https://cdn.jetphotos.com/full/6/70602_1625406149.jpg,


### PR DESCRIPTION
## Describe your changes
PLANE INFO:
Replace incorrect image for N46E/A597A6
-https://cdn.jetphotos.com/full/6/24303_1430579556.jpg
+https://cdn.jetphotos.com/full/1/81463_1151459930.jpg

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/sdr-enthusiasts/plane-alert-db/pulls) to support the maintainers.
