### PR TITLE
add pics for ae60d3, fix 4b9030 in plane_images.csv

### DIFF
--- a/plane_images.csv
+++ b/plane_images.csv
@@ -1693,7 +1693,7 @@ A7CAD8,,,,
 51100D,,,,
 778561,,,,
 4B8681,https://cdn.jetphotos.com/full/6/56632_1638676981.jpg,https://cdn.jetphotos.com/full/5/97649_1637719592.jpg,https://cdn.jetphotos.com/full/6/72955_1629620609.jpg,
-4b9030,https://cdn.jetphotos.com/full/6/20859_1636908864.jpg,https://cdn.jetphotos.com/full/6/73093_1601916839.jpg,https://cdn.jetphotos.com/full/5/54356_1597261550.jpg,
+4B9030,https://cdn.jetphotos.com/full/6/20859_1636908864.jpg,https://cdn.jetphotos.com/full/6/73093_1601916839.jpg,https://cdn.jetphotos.com/full/5/54356_1597261550.jpg,
 4B8C4B,https://cdn.jetphotos.com/full/5/14573_1635452931.jpg,https://cdn.jetphotos.com/full/6/30486_1634965813.jpg,https://cdn.jetphotos.com/full/5/42006_1631089207.jpg,
 0D80A4,https://cdn.jetphotos.com/full/1/63584_1238691402.jpg,https://cdn.jetphotos.com/full/2/88325_1208088027.jpg,https://cdn.jetphotos.com/full/2/20035_1161608940.jpg,
 0D8032,https://cdn.jetphotos.com/full/6/60556_1642108489.jpg,https://cdn.jetphotos.com/full/6/32235_1642998261.jpg,https://cdn.jetphotos.com/full/5/28162_1643400152.jpg,
@@ -13520,5 +13520,4 @@ A0DE90,https://cdn.jetphotos.com/full/5/1366724_1681003273.jpg,https://photos.fl
 AA197E,https://live.staticflickr.com/65535/50008900941_b6bb99e643_b.jpg,https://photos.flightaware.com/photos/retriever/cc9d55291272192546b683b776f0a7d8b3fd989d,https://cdn.jetphotos.com/full/5/51590_1585984074.jpg,https://live.staticflickr.com/65535/50013462471_2f1fb16783_b.jpg
 A81B13,https://cdn.jetphotos.com/full/5/44469_1542257762.jpg,https://cdn.jetphotos.com/full/6/89874_1530299074.jpg,https://live.staticflickr.com/65535/50670395777_53e5bd1746_k_d.jpg,https://live.staticflickr.com/65535/51283489319_769bdcd1f3_h.jpg
 AC64C6,https://cdn.jetphotos.com/full/5/66644_1629737991.jpg,https://cdn.jetphotos.com/full/6/34354_1440881994.jpg,https://live.staticflickr.com/465/19093069332_d1d94b3190_h.jpg,https://live.staticflickr.com/65535/52735468392_dc945a9682_h.jpg
-4B9030,,,,
-AE60D3,,,,
+AE60D3,https://cdn.jetphotos.com/full/5/44710_1662379506.jpg,https://www.airhistory.net/photos/0248210.jpg,,


### PR DESCRIPTION
## Describe your changes

add pics for ae60d3.

Also realized that fixing the capitalization of 4B9030 in plane-alert-db.csv did not propagate to plane_images.csv, but rather, it created a new entry for it while preserving the `4b9030` entry. So I just deleted the empty one and fixed the capitalization on the extant one with pics.

## Checklist before requesting a review

- [😬] I have performed a self-review of my code.
- [x] While waiting for someone to review your request, please help review [another open pull request](https://github.com/sdr-enthusiasts/plane-alert-db/pulls) to support the maintainers.
