### PR TITLE
added planes for rhizo, added new CAP category, fixed Army Air Corps …

### DIFF
--- a/plane-alert-db.csv
+++ b/plane-alert-db.csv
@@ -13580,5 +13580,5 @@ A1D63F,N21725,Optic Air,Cessna 172M Skyhawk,C172,Civ,Aerial Survey,Measuring Sti
 A37E79,N324PH,PHI Health,Eurocopter EC135 P2+,EC35,Civ,Air Ambo,Medical Evac,Saving Lives,Flying Doctors,http://www.phiairmedical.com/
 A462FE,N382CV,Civil Air Patrol,Textron Aviation 182T Skylane,C182,Civ,Air Force Auxiliary,Search and Rescue,Flying Vigilantes,CAP,https://w.wiki/8odd
 A64CC3,N505CP,Civil Air Patrol,Textron Aviation 182T Skylane,C182,Civ,Air Force Auxiliary,Search and Rescue,Flying Vigilantes,CAP,https://w.wiki/8odd
-A7F432,N611TV,Sky Helicopters Inc,Robinson R66 Turbine Newscopter,R66,Civ,Is This My Good Side,Vanity Plate,News Corporation,As Seen on TV,https://www.skyhelicopters.com/
+A7F432,N611TV,Sky Helicopters,Robinson R66 Turbine Newscopter,R66,Civ,Is This My Good Side,Vanity Plate,News Corporation,As Seen on TV,https://www.skyhelicopters.com/
 AC4407,N89LT,Surveying and Mapping,Vulcanair P.68C Victor,P68,Civ,Aerial Survey,Measuring Stick,Trundle Wheel,Ptolemy would be proud,https://www.sam.biz/

--- a/plane-alert-db.csv
+++ b/plane-alert-db.csv
@@ -67,100 +67,100 @@ A92949,N69KL,The Flying Bulls,Sukhoi Su-29,SU29,Civ,Already Has Wings,Display Te
 43C0EE,XX177,The Red Arrows,BAe Hawk T1a,HAWK,Mil,Turn And Burn,Display Team,Aerobatics,Aerobatic Teams,https://www.raf.mod.uk/display-teams/red-arrows
 407BBD,G-NGTC,The Starlings Display Team,Extra NG,EXNG,Civ,Aerobatics,The Starlings,Display Team,Aerobatic Teams,https://tinyurl.com/5vmpwb4w
 A11CF8,17-01609,United States Army,DHC-8-311,DH8C,Mil,Perfectly Serviceable Aircraft,Skydive,Golden Knights,Aerobatic Teams,https://w.wiki/4nFV
-43C93C,ZM714,Army Air Corp,AH-64E Apache,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Guardian,Army Air Corp,http://torinak.com/qaop#!tomahawk
-43C933,ZM705,Army Air Corps,AH-64E Apache,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Guardian,Army Air Corp,http://torinak.com/qaop#!tomahawk
-43C93A,ZM712,Army Air Corps,AH-64E Apache,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Guardian,Army Air Corp,http://torinak.com/qaop#!tomahawk
-43C72D,ZJ248,Army Air Corps,AS350 Squirrel,AS50,Mil,Kung Fu Grip,Chopper,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43CF3A,ZZ388,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43CF34,ZZ395,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43CF33,ZZ394,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43CF32,ZZ393,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43CF30,ZZ391,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43CF2F,ZZ390,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43CF2E,ZZ389,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43C767,ZZ526,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43C766,ZZ525,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43C765,ZZ524,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43C764,ZZ523,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43C761,ZZ520,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43C758,ZZ511,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43C757,ZZ510,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43C6EB,ZZ387,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43C6E9,ZZ385,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43C6E7,ZZ383,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43C6E6,ZZ382,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43C6C4,ZZ410,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43C6C3,ZZ409,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43C6C2,ZZ408,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43C6C1,ZZ407,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43C6BF,ZZ405,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43C6BE,ZZ404,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43C6BB,ZZ398,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43C56E,ZZ401,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43C90E,ZJ969,Army Air Corps,Bell 212 AH1,B212,Mil,Choppa,I Am Old,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43C90C,ZH816,Army Air Corps,Bell 212 AH1,B212,Mil,Choppa,I Am Old,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43C90B,ZH814,Army Air Corps,Bell 212 AH1,B212,Mil,Choppa,I Am Old,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43C72C,ZJ249,Army Air Corps,Eurocopter AS350 Squirrel HT1,AS50,Mil,Kung Fu Grip,Chopper,The Skys No Limit,Army Air Corp,https://www.nam.ac.uk/explore/army-air-corps
-43C72B,ZJ250,Army Air Corps,Eurocopter AS350 Squirrel HT1,AS50,Mil,Kung Fu Grip,Chopper,The Skys No Limit,Army Air Corp,https://www.nam.ac.uk/explore/army-air-corps
-43C728,ZJ254,Army Air Corps,Eurocopter AS350 Squirrel HT1,AS50,Mil,Kung Fu Grip,Chopper,The Skys No Limit,Army Air Corp,https://www.nam.ac.uk/explore/army-air-corps
-43C710,ZJ253,Army Air Corps,Eurocopter AS350 Squirrel HT1,AS50,Mil,Kung Fu Grip,Chopper,The Skys No Limit,Army Air Corp,https://www.nam.ac.uk/explore/army-air-corps
-43C239,ZB693,Army Air Corps,Gazelle SA31B,GAZL,Mil,Kung Fu Grip,Choppa,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43C237,ZB691,Army Air Corps,Gazelle SA31B,GAZL,Mil,Kung Fu Grip,Choppa,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43C22F,ZB679,Army Air Corps,Gazelle SA31B,GAZL,Mil,Kung Fu Grip,Choppa,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43C22E,ZB678,Army Air Corps,Gazelle SA31B,GAZL,Mil,Kung Fu Grip,Choppa,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43C22B,ZB674,Army Air Corps,Gazelle SA31B,GAZL,Mil,Kung Fu Grip,Choppa,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43C22A,ZB671,Army Air Corps,Gazelle SA31B,GAZL,Mil,Kung Fu Grip,Choppa,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43C228,ZB669,Army Air Corps,Gazelle SA31B,GAZL,Mil,Kung Fu Grip,Choppa,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43C222,ZB665,Army Air Corps,Gazelle SA31B,GAZL,Mil,Kung Fu Grip,Choppa,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43C21F,ZA775,Army Air Corps,Gazelle SA31B,GAZL,Mil,Kung Fu Grip,Choppa,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43C21C,ZA772,Army Air Corps,Gazelle SA31B,GAZL,Mil,Kung Fu Grip,Choppa,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43C219,ZA766,Army Air Corps,Gazelle SA31B,GAZL,Mil,Kung Fu Grip,Choppa,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43C218,ZA736,Army Air Corps,Gazelle SA31B,GAZL,Mil,Kung Fu Grip,Choppa,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43C216,ZA731,Army Air Corps,Gazelle SA31B,GAZL,Mil,Kung Fu Grip,Choppa,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43C123,XZ340,Army Air Corps,Gazelle SA31B,GAZL,Mil,Kung Fu Grip,Choppa,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43C11E,XZ334,Army Air Corps,Gazelle SA31B,GAZL,Mil,Kung Fu Grip,Choppa,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43C117,XZ326,Army Air Corps,Gazelle SA31B,GAZL,Mil,Kung Fu Grip,Choppa,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43C112,XZ320,Army Air Corps,Gazelle SA31B,GAZL,Mil,Kung Fu Grip,Choppa,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43C0CC,XZ290,Army Air Corps,Gazelle SA31B,GAZL,Mil,Kung Fu Grip,Choppa,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43C0BA,XX419,Army Air Corps,Gazelle SA31B,GAZL,Mil,Kung Fu Grip,Choppa,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43C0B4,XX405,Army Air Corps,Gazelle SA31B,GAZL,Mil,Kung Fu Grip,Choppa,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43C081,XW865,Army Air Corps,Gazelle SA31B,GAZL,Mil,Kung Fu Grip,Choppa,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43C07E,XW848,Army Air Corps,Gazelle SA31B,GAZL,Mil,Kung Fu Grip,Choppa,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43C07D,XW847,Army Air Corps,Gazelle SA31B,GAZL,Mil,Kung Fu Grip,Choppa,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43C07C,XW846,Army Air Corps,Gazelle SA31B,GAZL,Mil,Kung Fu Grip,Choppa,The Skys No Limit,Army Air Corp,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
-43C27E,ZJ233,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corp,http://torinak.com/qaop#!tomahawk
-43C27C,ZJ209,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corp,http://torinak.com/qaop#!tomahawk
-43C27B,ZJ230,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corp,http://torinak.com/qaop#!tomahawk
-43C279,ZJ228,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corp,http://torinak.com/qaop#!tomahawk
-43C278,ZJ227,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corp,http://torinak.com/qaop#!tomahawk
-43C277,ZJ226,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corp,http://torinak.com/qaop#!tomahawk
-43C275,ZJ224,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corp,http://torinak.com/qaop#!tomahawk
-43C274,ZJ223,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corp,http://torinak.com/qaop#!tomahawk
-43C272,ZJ221,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corp,http://torinak.com/qaop#!tomahawk
-43C271,ZJ220,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corp,http://torinak.com/qaop#!tomahawk
-43C26F,ZJ218,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corp,http://torinak.com/qaop#!tomahawk
-43C26E,ZJ217,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corp,http://torinak.com/qaop#!tomahawk
-43C26D,ZJ216,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corp,http://torinak.com/qaop#!tomahawk
-43C26C,ZJ215,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corp,http://torinak.com/qaop#!tomahawk
-43C26A,ZJ213,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corp,http://torinak.com/qaop#!tomahawk
-43C268,ZJ211,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corp,http://torinak.com/qaop#!tomahawk
-43C267,ZJ210,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corp,http://torinak.com/qaop#!tomahawk
-43C265,ZJ208,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corp,http://torinak.com/qaop#!tomahawk
-43C273,ZJ204,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corp,http://torinak.com/qaop#!tomahawk
-43C25C,ZJ199,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corp,http://torinak.com/qaop#!tomahawk
-43C25B,ZJ198,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corp,http://torinak.com/qaop#!tomahawk
-43C25A,ZJ197,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corp,http://torinak.com/qaop#!tomahawk
-43C259,ZJ196,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corp,http://torinak.com/qaop#!tomahawk
-43C258,ZJ195,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corp,http://torinak.com/qaop#!tomahawk
-43C257,ZJ194,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corp,http://torinak.com/qaop#!tomahawk
-43C255,ZJ192,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corp,http://torinak.com/qaop#!tomahawk
-43C254,ZJ191,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corp,http://torinak.com/qaop#!tomahawk
-43C252,ZJ189,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corp,http://torinak.com/qaop#!tomahawk
-43C251,ZJ188,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corp,http://torinak.com/qaop#!tomahawk
-43C250,ZJ187,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corp,http://torinak.com/qaop#!tomahawk
-43C24F,ZJ186,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corp,http://torinak.com/qaop#!tomahawk
-43C24B,ZJ182,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corp,http://torinak.com/qaop#!tomahawk
-43C24A,ZJ181,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corp,http://torinak.com/qaop#!tomahawk
+43C93C,ZM714,Army Air Corps,AH-64E Apache,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Guardian,Army Air Corps,http://torinak.com/qaop#!tomahawk
+43C933,ZM705,Army Air Corps,AH-64E Apache,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Guardian,Army Air Corps,http://torinak.com/qaop#!tomahawk
+43C93A,ZM712,Army Air Corps,AH-64E Apache,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Guardian,Army Air Corps,http://torinak.com/qaop#!tomahawk
+43C72D,ZJ248,Army Air Corps,AS350 Squirrel,AS50,Mil,Kung Fu Grip,Chopper,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43CF3A,ZZ388,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43CF34,ZZ395,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43CF33,ZZ394,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43CF32,ZZ393,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43CF30,ZZ391,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43CF2F,ZZ390,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43CF2E,ZZ389,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43C767,ZZ526,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43C766,ZZ525,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43C765,ZZ524,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43C764,ZZ523,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43C761,ZZ520,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43C758,ZZ511,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43C757,ZZ510,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43C6EB,ZZ387,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43C6E9,ZZ385,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43C6E7,ZZ383,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43C6E6,ZZ382,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43C6C4,ZZ410,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43C6C3,ZZ409,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43C6C2,ZZ408,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43C6C1,ZZ407,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43C6BF,ZZ405,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43C6BE,ZZ404,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43C6BB,ZZ398,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43C56E,ZZ401,Army Air Corps,AW159 Wildcat AH1,LYNX,Mil,Go Fast,Chopper,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43C90E,ZJ969,Army Air Corps,Bell 212 AH1,B212,Mil,Choppa,I Am Old,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43C90C,ZH816,Army Air Corps,Bell 212 AH1,B212,Mil,Choppa,I Am Old,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43C90B,ZH814,Army Air Corps,Bell 212 AH1,B212,Mil,Choppa,I Am Old,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43C72C,ZJ249,Army Air Corps,Eurocopter AS350 Squirrel HT1,AS50,Mil,Kung Fu Grip,Chopper,The Skys No Limit,Army Air Corps,https://www.nam.ac.uk/explore/army-air-corps
+43C72B,ZJ250,Army Air Corps,Eurocopter AS350 Squirrel HT1,AS50,Mil,Kung Fu Grip,Chopper,The Skys No Limit,Army Air Corps,https://www.nam.ac.uk/explore/army-air-corps
+43C728,ZJ254,Army Air Corps,Eurocopter AS350 Squirrel HT1,AS50,Mil,Kung Fu Grip,Chopper,The Skys No Limit,Army Air Corps,https://www.nam.ac.uk/explore/army-air-corps
+43C710,ZJ253,Army Air Corps,Eurocopter AS350 Squirrel HT1,AS50,Mil,Kung Fu Grip,Chopper,The Skys No Limit,Army Air Corps,https://www.nam.ac.uk/explore/army-air-corps
+43C239,ZB693,Army Air Corps,Gazelle SA31B,GAZL,Mil,Kung Fu Grip,Choppa,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43C237,ZB691,Army Air Corps,Gazelle SA31B,GAZL,Mil,Kung Fu Grip,Choppa,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43C22F,ZB679,Army Air Corps,Gazelle SA31B,GAZL,Mil,Kung Fu Grip,Choppa,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43C22E,ZB678,Army Air Corps,Gazelle SA31B,GAZL,Mil,Kung Fu Grip,Choppa,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43C22B,ZB674,Army Air Corps,Gazelle SA31B,GAZL,Mil,Kung Fu Grip,Choppa,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43C22A,ZB671,Army Air Corps,Gazelle SA31B,GAZL,Mil,Kung Fu Grip,Choppa,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43C228,ZB669,Army Air Corps,Gazelle SA31B,GAZL,Mil,Kung Fu Grip,Choppa,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43C222,ZB665,Army Air Corps,Gazelle SA31B,GAZL,Mil,Kung Fu Grip,Choppa,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43C21F,ZA775,Army Air Corps,Gazelle SA31B,GAZL,Mil,Kung Fu Grip,Choppa,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43C21C,ZA772,Army Air Corps,Gazelle SA31B,GAZL,Mil,Kung Fu Grip,Choppa,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43C219,ZA766,Army Air Corps,Gazelle SA31B,GAZL,Mil,Kung Fu Grip,Choppa,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43C218,ZA736,Army Air Corps,Gazelle SA31B,GAZL,Mil,Kung Fu Grip,Choppa,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43C216,ZA731,Army Air Corps,Gazelle SA31B,GAZL,Mil,Kung Fu Grip,Choppa,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43C123,XZ340,Army Air Corps,Gazelle SA31B,GAZL,Mil,Kung Fu Grip,Choppa,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43C11E,XZ334,Army Air Corps,Gazelle SA31B,GAZL,Mil,Kung Fu Grip,Choppa,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43C117,XZ326,Army Air Corps,Gazelle SA31B,GAZL,Mil,Kung Fu Grip,Choppa,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43C112,XZ320,Army Air Corps,Gazelle SA31B,GAZL,Mil,Kung Fu Grip,Choppa,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43C0CC,XZ290,Army Air Corps,Gazelle SA31B,GAZL,Mil,Kung Fu Grip,Choppa,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43C0BA,XX419,Army Air Corps,Gazelle SA31B,GAZL,Mil,Kung Fu Grip,Choppa,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43C0B4,XX405,Army Air Corps,Gazelle SA31B,GAZL,Mil,Kung Fu Grip,Choppa,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43C081,XW865,Army Air Corps,Gazelle SA31B,GAZL,Mil,Kung Fu Grip,Choppa,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43C07E,XW848,Army Air Corps,Gazelle SA31B,GAZL,Mil,Kung Fu Grip,Choppa,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43C07D,XW847,Army Air Corps,Gazelle SA31B,GAZL,Mil,Kung Fu Grip,Choppa,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43C07C,XW846,Army Air Corps,Gazelle SA31B,GAZL,Mil,Kung Fu Grip,Choppa,The Skys No Limit,Army Air Corps,https://en.wikipedia.org/wiki/Army_Air_Corps_(United_Kingdom)
+43C27E,ZJ233,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corps,http://torinak.com/qaop#!tomahawk
+43C27C,ZJ209,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corps,http://torinak.com/qaop#!tomahawk
+43C27B,ZJ230,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corps,http://torinak.com/qaop#!tomahawk
+43C279,ZJ228,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corps,http://torinak.com/qaop#!tomahawk
+43C278,ZJ227,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corps,http://torinak.com/qaop#!tomahawk
+43C277,ZJ226,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corps,http://torinak.com/qaop#!tomahawk
+43C275,ZJ224,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corps,http://torinak.com/qaop#!tomahawk
+43C274,ZJ223,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corps,http://torinak.com/qaop#!tomahawk
+43C272,ZJ221,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corps,http://torinak.com/qaop#!tomahawk
+43C271,ZJ220,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corps,http://torinak.com/qaop#!tomahawk
+43C26F,ZJ218,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corps,http://torinak.com/qaop#!tomahawk
+43C26E,ZJ217,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corps,http://torinak.com/qaop#!tomahawk
+43C26D,ZJ216,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corps,http://torinak.com/qaop#!tomahawk
+43C26C,ZJ215,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corps,http://torinak.com/qaop#!tomahawk
+43C26A,ZJ213,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corps,http://torinak.com/qaop#!tomahawk
+43C268,ZJ211,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corps,http://torinak.com/qaop#!tomahawk
+43C267,ZJ210,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corps,http://torinak.com/qaop#!tomahawk
+43C265,ZJ208,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corps,http://torinak.com/qaop#!tomahawk
+43C273,ZJ204,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corps,http://torinak.com/qaop#!tomahawk
+43C25C,ZJ199,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corps,http://torinak.com/qaop#!tomahawk
+43C25B,ZJ198,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corps,http://torinak.com/qaop#!tomahawk
+43C25A,ZJ197,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corps,http://torinak.com/qaop#!tomahawk
+43C259,ZJ196,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corps,http://torinak.com/qaop#!tomahawk
+43C258,ZJ195,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corps,http://torinak.com/qaop#!tomahawk
+43C257,ZJ194,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corps,http://torinak.com/qaop#!tomahawk
+43C255,ZJ192,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corps,http://torinak.com/qaop#!tomahawk
+43C254,ZJ191,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corps,http://torinak.com/qaop#!tomahawk
+43C252,ZJ189,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corps,http://torinak.com/qaop#!tomahawk
+43C251,ZJ188,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corps,http://torinak.com/qaop#!tomahawk
+43C250,ZJ187,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corps,http://torinak.com/qaop#!tomahawk
+43C24F,ZJ186,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corps,http://torinak.com/qaop#!tomahawk
+43C24B,ZJ182,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corps,http://torinak.com/qaop#!tomahawk
+43C24A,ZJ181,Army Air Corps,Westland WAH-64D Apache AH1,H64,Mil,Brrrrrrrrrrrrrrrrrrrrrrt,Gunship,Longbow,Army Air Corps,http://torinak.com/qaop#!tomahawk
 AC67F2,N899NC,21st Century Fox,Gulfstream G550,GLF5,Civ,Is This My Good Side,Hollywood,News Corporation,As Seen on TV,https://en.wikipedia.org/wiki/21st_Century_Fox
 ADCA0B,N988NC,21st Century Fox,Gulfstream G650 ER,GLF6,Civ,Is This My Good Side,Hollywood,News Corporation,As Seen on TV,https://en.wikipedia.org/wiki/21st_Century_Fox
 AC705B,N900NC,21st Century Fox,Gulfstream G650 ER,GLF6,Civ,Is This My Good Side,Hollywood,News Corporation,As Seen on TV,https://en.wikipedia.org/wiki/21st_Century_Fox
@@ -4421,7 +4421,7 @@ A05291,N12NM,Private,Zivko Edge 540K,EDGE,Civ,Unlimted Aerobatics,High G,Red Bul
 484BC8,PH-PEP,Sky Unlimited bv,Pitts Special S-2B,PTS2,Civ,Biplane,Do A Barrel Roll,Aerobatics,Joe Cool,https://en.wikipedia.org/wiki/Pitts_Special
 484989,PH-PGP,Wings over Holland,Pitts Special S-2A,PTS2,Civ,Biplane,Do A Barrel Roll,Aerobatics,Joe Cool,https://en.wikipedia.org/wiki/Pitts_Special
 491429,CS-EAI,Aero Club de Portugal,OGMA DHC-1 Chipmunk T20,DHC1,Civ,Jump Johnny Jump,Obrigado,Air Training Corps,Jump Johnny Jump,https://youtu.be/JMz_gONS8X0
-407B74,G-CLWK,Army Air Corp,DHC-1 Chipmunk T10,DHC1,Civ,Air Experience Flight,Jump Johnny Jump,Army Air Corp,Jump Johnny Jump,https://youtu.be/JMz_gONS8X0
+407B74,G-CLWK,Army Air Corps,DHC-1 Chipmunk T10,DHC1,Civ,Air Experience Flight,Jump Johnny Jump,Army Air Corps,Jump Johnny Jump,https://youtu.be/JMz_gONS8X0
 401AF0,G-BBMV,Boultbee,DHC-1 Chipmunk 22,DHC1,Civ,Air Experience Flight,Jump Johnny Jump,Air Training Corps,Jump Johnny Jump,https://youtu.be/JMz_gONS8X0
 7C02B3,VH-ATH,Pivate,DHC-1 Chipmunk 22,DHC1,Civ,Air Experience Flight,Jump Johnny Jump,Air Training Corps,Jump Johnny Jump,https://youtu.be/JMz_gONS8X0
 A8825C,N64750,Planes of Fame Air Museum,OGMA DHC-1 Chipmunk T20,DHC1,Civ,Jump Johnny Jump,Obrigado,Air Training Corps,Jump Johnny Jump,https://youtu.be/JMz_gONS8X0
@@ -13152,16 +13152,16 @@ A03760,N113AH,TVPX Aircraft Solutions Inc Trustee,Eurocopter MBB-BK 117 C-2 (EC1
 A278F9,N259AM,Air Methods Corp,Eurocopter EC-130 B4,EC30,Civ,Air Ambo,Medical Evac,Saving Lives,Flying Doctors,https://www.airmethods.com/
 A31DAE,N30HF,HALO-Flight Inc,Bell 407,B407,Civ,Air Ambo,Medical Evac,Saving Lives,Flying Doctors,https://haloflight.org/
 A3452D,N31HF,HALO-Flight Inc,Bell 407,B407,Civ,Air Ambo,Medical Evac,Saving Lives,Flying Doctors,https://haloflight.org/
-A3971C,N330PH,PHI Health LLC,Eurocopter EC135 P2+,EC35,Civ,Air Ambo,Medical Evac,Saving Lives,Flying Doctors,https://www.phiairmedical.com/
-A39E8A,N332PH,PHI Health LLC,Eurocopter EC135 P2+,EC35,Civ,Air Ambo,Medical Evac,Saving Lives,Flying Doctors,https://www.phiairmedical.com/
+A3971C,N330PH,PHI Health,Eurocopter EC135 P2+,EC35,Civ,Air Ambo,Medical Evac,Saving Lives,Flying Doctors,https://www.phiairmedical.com/
+A39E8A,N332PH,PHI Health,Eurocopter EC135 P2+,EC35,Civ,Air Ambo,Medical Evac,Saving Lives,Flying Doctors,https://www.phiairmedical.com/
 A3942B,N33HF,HALO-Flight Inc,Bell 407,B407,Civ,Air Ambo,Medical Evac,Saving Lives,Flying Doctors,https://haloflight.org/
 A51DC3,N429HF,HALO-Flight Inc,Bell 429 GlobalRanger,B429,Civ,Air Ambo,Medical Evac,Saving Lives,Flying Doctors,https://haloflight.org/
 ACBFEC,N920U,Air Methods Corp,Eurocopter EC-130 B4,EC30,Civ,Air Ambo,Medical Evac,Saving Lives,Flying Doctors,https://www.airmethods.com/
 AC97D0,N910MT,Med-Trans Corp,Eurocopter EC135 P3,EC35,Civ,Air Ambo,Medical Evac,Saving Lives,Flying Doctors,https://www.med-trans.net/
-A5CA47,N472TX,PHI Health LLC,Bell 407,B407,Civ,Air Ambo,Medical Evac,Saving Lives,Flying Doctors,https://www.phiairmedical.com/
-AA0325,N744TX,PHI Health LLC,Bell 407,B407,Civ,Air Ambo,Medical Evac,Saving Lives,Flying Doctors,https://www.phiairmedical.com/
+A5CA47,N472TX,PHI Health,Bell 407,B407,Civ,Air Ambo,Medical Evac,Saving Lives,Flying Doctors,https://www.phiairmedical.com/
+AA0325,N744TX,PHI Health,Bell 407,B407,Civ,Air Ambo,Medical Evac,Saving Lives,Flying Doctors,https://www.phiairmedical.com/
 AA06DC,N745TX,Mother Frances Hospital,Eurocopter MBB-BK 117 C-2 (EC145),EC45,Civ,Air Ambo,Medical Evac,Saving Lives,Flying Doctors,https://www.christushealth.org/locations/tyler-hospital
-AB6CAC,N835TX,PHI Health LLC,Eurocopter EC135 P2+,EC35,Civ,Air Ambo,Medical Evac,Saving Lives,Flying Doctors,https://www.phiairmedical.com/
+AB6CAC,N835TX,PHI Health,Eurocopter EC135 P2+,EC35,Civ,Air Ambo,Medical Evac,Saving Lives,Flying Doctors,https://www.phiairmedical.com/
 A68A13,N520MT,Med-Trans Corp,Bell 407,B407,Civ,Air Ambo,Medical Evac,Saving Lives,Flying Doctors,https://www.med-trans.net/
 A7698F,N577MT,Bank of Utah Trustee,Eurocopter EC135 P3,EC35,Civ,Air Ambo,Medical Evac,Saving Lives,Flying Doctors,https://www.med-trans.net/
 A5C292,N470RA,Rocky Mountian Holdings LLC,Bell 407,B407,Civ,Air Ambo,Medical Evac,Saving Lives,Flying Doctors,https://www.airmethods.com/
@@ -13575,3 +13575,10 @@ AE0412,163920,United States Navy,Boeing E-6B Mercury,E6,Mil,Quarterback,Looking 
 AE6C18,170276,United States Marine Corps,KC-130J Super Hercules,C30J,Mil,Harvest Hawk,Refuel,Hotel Mode,United States Marine Corps,https://w.wiki/7ok9#Harvest_HAWK
 C2C363,330002,Royal Canadian Air Force,Airbus CC-330 Husky,A332,Mil,Strategic Airlift,Cargo,O Canada,Other Air Forces,https://w.wiki/8oba
 AE6807,Tactical,United States Navy,Boeing P-8A Poseidon,P8,Mil,One Ping Only Vasily,Maritime Patrol,Eye In The Sky,Oxcart,https://w.wiki/3qBW
+A0AD1F,N14244,Pacific Fleet Aviation,Piper PA-23 Aztec 250E,PA27,Civ,Aerial Survey,Measuring Stick,Trundle Wheel,Ptolemy would be proud,https://www.eagleview.com/
+A1D63F,N21725,Optic Air,Cessna 172M Skyhawk,C172,Civ,Aerial Survey,Measuring Stick,Trundle Wheel,Ptolemy would be proud,https://www.opticair.net/
+A37E79,N324PH,PHI Health,Eurocopter EC135 P2+,EC35,Civ,Air Ambo,Medical Evac,Saving Lives,Flying Doctors,http://www.phiairmedical.com/
+A462FE,N382CV,Civil Air Patrol,Textron Aviation 182T Skylane,C182,Civ,Air Force Auxiliary,Search and Rescue,Flying Vigilantes,CAP,https://w.wiki/8odd
+A64CC3,N505CP,Civil Air Patrol,Textron Aviation 182T Skylane,C182,Civ,Air Force Auxiliary,Search and Rescue,Flying Vigilantes,CAP,https://w.wiki/8odd
+A7F432,N611TV,Sky Helicopters Inc,Robinson R66 Turbine Newscopter,R66,Civ,Is This My Good Side,Vanity Plate,News Corporation,As Seen on TV,https://www.skyhelicopters.com/
+AC4407,N89LT,Surveying and Mapping,Vulcanair P.68C Victor,P68,Civ,Aerial Survey,Measuring Stick,Trundle Wheel,Ptolemy would be proud,https://www.sam.biz/

--- a/plane_images.csv
+++ b/plane_images.csv
@@ -1166,7 +1166,7 @@ AE2687,https://cdn.jetphotos.com/full/5/32484_1639924399.jpg,https://cdn.jetphot
 AE2686,https://cdn.jetphotos.com/full/6/45795_1642121550.jpg,https://cdn.jetphotos.com/full/6/45795_1642121550.jpg,https://cdn.jetphotos.com/full/5/14584_1642473074.jpg,
 AE2685,https://cdn.jetphotos.com/full/6/36414_1640698979.jpg,https://cdn.jetphotos.com/full/5/25460_1631354090.jpg,https://cdn.jetphotos.com/full/5/76896_1630659458.jpg,
 AE2684,https://cdn.jetphotos.com/full/6/17289_1642029070.jpg,https://cdn.jetphotos.com/full/5/73644_1641623261.jpg,https://cdn.jetphotos.com/full/5/27531_1640719854.jpg,
-AE2683,https://cdn.jetphotos.com/full/5/86456_1640756218.jpg,https://cdn.jetphotos.com/full/5/86456_1640756218.jpg,https://cdn.jetphotos.com/full/5/86456_1640756218.jpg,
+AE2683,https://cdn.jetphotos.com/400/5/697018_1702424267.jpg,https://cdn.jetphotos.com/400/5/67911_1478369662.jpg,,
 AE2682,https://cdn.jetphotos.com/full/6/47274_1640092189.jpg,https://cdn.jetphotos.com/full/5/81647_1638067890.jpg,https://cdn.jetphotos.com/full/6/66899_1635758365.jpg,
 AE2681,https://cdn.jetphotos.com/full/5/82911_1641950691.jpg,https://cdn.jetphotos.com/full/5/61793_1640467640.jpg,https://cdn.jetphotos.com/full/5/82911_1641950691.jpg,
 AE2680,https://www.helis.com/h/h65_6538.jpg,https://live.staticflickr.com/4043/4361679696_d69a17bf47_b.jpg,https://live.staticflickr.com/2508/3890842197_f37f870795_b.jpg,https://live.staticflickr.com/65535/51819792843_00a1450b0b_z.jpg

--- a/plane_images.csv
+++ b/plane_images.csv
@@ -13608,3 +13608,10 @@ AE0412,https://cdn.jetphotos.com/full/6/13775_1604302571.jpg,https://cdn.jetphot
 AE6C18,https://cdn.jetphotos.com/full/5/90774_1646516848.jpg,https://cdn.jetphotos.com/full/6/45286_1662966503.jpg,https://cdn.jetphotos.com/full/5/34954_1649581646.jpg,https://cdn.jetphotos.com/full/5/67714_1662966422.jpg
 C2C363,https://cdn.jetphotos.com/full/6/1724677_1701817291.jpg,https://cdn.jetphotos.com/full/6/406914_1701817522.jpg,https://cdn.jetphotos.com/full/6/620068_1700397986.jpg,https://cdn.jetphotos.com/full/5/639623_1699112873.jpg
 AE6807,,,,
+A0AD1F,https://live.staticflickr.com/65535/48921123842_922fe46cf6_b.jpg,https://photos.flightaware.com/photos/retriever/96974f015a786dad501c86de299ebdc0835d439b,https://photos.flightaware.com/photos/retriever/d9e26fb01bd17dcfa19cefcb956c28d00f4dceb1,https://photos.flightaware.com/photos/retriever/922a4e38456adbbfe917c55a238e0588a4f89f52
+A1D63F,https://photos.flightaware.com/photos/retriever/f8af38fa2bc652db7bfef368c6962e4bf7de63ca,,,
+A37E79,https://photos.flightaware.com/photos/retriever/4f0386d72ba1f466292ab03de644fa5367606927,https://photos.flightaware.com/photos/retriever/d362721c3813c712d4f82fb72ed8f0a98d929de6,https://photos.flightaware.com/photos/retriever/f6f2dfafb4a65d246be08f0f434e65ee48dd15b3,https://photos.flightaware.com/photos/retriever/0cea6723e4182c6c67cacca03b5018fc74efbac8
+A462FE,https://photos.flightaware.com/photos/retriever/a3b46722e4971790d66c11684a2c152cc1b6454f,https://photos.flightaware.com/photos/retriever/8493680ac16736209a83068658a35b0d3d07816b,,
+A64CC3,https://cdn.jetphotos.com/full/6/96027_1663529905.jpg,https://photos.flightaware.com/photos/retriever/0997183817b7db7b193e14dc55153ff559c4440c,https://photos.flightaware.com/photos/retriever/564a7bf6f74ec0534426695c1fa3ba271aefbe9b,
+A7F432,https://cdn.jetphotos.com/full/5/62420_1647917150.jpg,https://photos.flightaware.com/photos/retriever/5801c8b4f25cb9e9b489e589ef2fa90f3f311693,,
+AC4407,https://live.staticflickr.com/3616/3297378279_dcfe0fa70f_b.jpg,https://live.staticflickr.com/3658/3298206036_32262c0759_b.jpg,https://live.staticflickr.com/3356/3297379375_7d194dee05_b.jpg,

--- a/readme.mustache
+++ b/readme.mustache
@@ -60,7 +60,7 @@ Think of categories like groups, with similar or related aircraft listed togethe
 |--------|-----------|----:|
 |Aerial Firefighter|Firefighting Aircraft|{{aerial_firefighter_count}}|
 |Aerobatic Teams|Red Arrows, Blue Angels, etc.|{{aerobatic_count}}|
-|Army Air Corp|UK Army Air Corp, mainly Helicopters|{{air_corp_count}}|
+|Army Air Corps|UK Army Air Corps, mainly Helicopters|{{air_corps_count}}|
 |As Seen on TV|Companies and Brands|{{seen_on_tv_count}}|
 |Big Hello|Large Helicopters (sic)|{{big_hello_count}}|
 |Bizjets|Fancy pants planes for fancy pants people|{{bizjets_count}}|
@@ -107,6 +107,7 @@ Think of categories like groups, with similar or related aircraft listed togethe
 |Watch Me Fly|Flying and Training Schools|{{watch_fly_count}}|
 |You came here in that thing?|Microlights, tiny planes and helis..think Yakima Super Breezy.|{{that_thing_count}}|
 |Zoomies|Fast jets, fighters. Anything that moves fast.|{{zoomies_count}}|
+|CAP|Civil Air Patrol.|{{cap_count}}|
 
 ## Planefence
 

--- a/readme.mustache
+++ b/readme.mustache
@@ -64,6 +64,7 @@ Think of categories like groups, with similar or related aircraft listed togethe
 |As Seen on TV|Companies and Brands|{{seen_on_tv_count}}|
 |Big Hello|Large Helicopters (sic)|{{big_hello_count}}|
 |Bizjets|Fancy pants planes for fancy pants people|{{bizjets_count}}|
+|CAP|Civil Air Patrol.|{{cap_count}}|
 |Climate Crisis|Oil Companies, Large Business Jets - BBJs and ACJs|{{climate_crisis_count}}|
 |Coastguard|Coastguard, Customs and Border Patrols|{{coastguard_count}}|
 |Da Comrade|Russian or Soviet Aircraft|{{da_comrade_count}}|
@@ -107,7 +108,6 @@ Think of categories like groups, with similar or related aircraft listed togethe
 |Watch Me Fly|Flying and Training Schools|{{watch_fly_count}}|
 |You came here in that thing?|Microlights, tiny planes and helis..think Yakima Super Breezy.|{{that_thing_count}}|
 |Zoomies|Fast jets, fighters. Anything that moves fast.|{{zoomies_count}}|
-|CAP|Civil Air Patrol.|{{cap_count}}|
 
 ## Planefence
 

--- a/scripts/update_readme.py
+++ b/scripts/update_readme.py
@@ -65,7 +65,7 @@ with open("readme.mustache", "r") as template:
                         category_df["Category"] == "Aerobatic Teams"
                     ].shape[0],
                     "air_corp_count": category_df[
-                        category_df["Category"] == "Army Air Corp"
+                        category_df["Category"] == "Army Air Corps"
                     ].shape[0],
                     "seen_on_tv_count": category_df[
                         category_df["Category"] == "As Seen on TV"
@@ -199,6 +199,9 @@ with open("readme.mustache", "r") as template:
                     ].shape[0],
                     "zoomies_count": category_df[
                         category_df["Category"] == "Zoomies"
+                    ].shape[0],
+                    "cap_count": category_df[
+                        category_df["Category"] == "CAP"
                     ].shape[0],
                     "ukraine_count": category_df[
                         category_df["Category"] == "Ukraine"

--- a/scripts/update_readme.py
+++ b/scripts/update_readme.py
@@ -64,7 +64,7 @@ with open("readme.mustache", "r") as template:
                     "aerobatic_count": category_df[
                         category_df["Category"] == "Aerobatic Teams"
                     ].shape[0],
-                    "air_corp_count": category_df[
+                    "air_corps_count": category_df[
                         category_df["Category"] == "Army Air Corps"
                     ].shape[0],
                     "seen_on_tv_count": category_df[


### PR DESCRIPTION
Added planes for rhizo from Discord.
Fixed pics for USCG 🐬 AE2683
Corrected 'Army Air Corp' category and text to 'Corps'
Added new 'CAP' category for Civil Air Patrol aircraft
Edited mustache thing and python to support new CAP category and corrected Corps text
Removed some 'LLC's to bring the PHI Health birds into line

## Checklist before requesting a review

- [lol] I have performed a self-review of my code.
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/sdr-enthusiasts/plane-alert-db/pulls) to support the maintainers.
