### PR TITLE
add some hawx

### DIFF
--- a/plane-alert-db.csv
+++ b/plane-alert-db.csv
@@ -13465,7 +13465,6 @@ AE212D,01-26890,United States Army,UH-60L Blackhawk,H60,Mil,Get To The Choppa,Ut
 AE08F8,84-24375,United States Army,C-12U Huron,BE20,Mil,Embassy Support,Not So VIP,Light Cargo,Toy Soldiers,https://w.wiki/8p9A
 ADFEDE,86-60088,United States Army,C-12U Huron,BE20,Mil,Embassy Support,Not So VIP,Light Cargo,Toy Soldiers,https://w.wiki/8p9A
 AE0997,95-26611,United States Army,UH-60L Blackhawk,H60,Mil,Get To The Choppa,Utility,Troop Transport,Toy Soldiers,https://w.wiki/3nxX
-AE6284,Tactical,United States Navy,Boeing P-8A Poseidon,P8,Mil,One Ping Only Vasily,Maritime Patrol,Eye In The Sky,Oxcart,https://w.wiki/3qBW
 AE6813,Tactical,United States Navy,Boeing P-8A Poseidon,P8,Mil,One Ping Only Vasily,Maritime Patrol,Eye In The Sky,Oxcart,https://w.wiki/3qBW
 AE6407,61-0904,USAF,Northrop T-38A Talon,T38,Mil,Training Wheels,Bicycle Made For Two,To Fly Fight And Win,USAF,https://w.wiki/7y3F
 AE6401,70-1559,USAF,Northrop T-38A Talon,T38,Mil,Training Wheels,Bicycle Made For Two,To Fly Fight And Win,USAF,https://w.wiki/7y3F

--- a/plane-alert-db.csv
+++ b/plane-alert-db.csv
@@ -13589,3 +13589,9 @@ ADFDD0,92-03328,United States Army,Beech C-12V Huron,BE20,Mil,Embassy Support,No
 080010,98-00010,United States Army,Cessna UC-35A Citation,C560,Mil,VIP Transport,Bizjet,Must Be Nice,Toy Soldiers,https://w.wiki/8p9F
 AE483A,08-20105,United States Army,Sikorsky UH-60M Blackhawk,H60,Mil,Get To The Choppa,Military Transport,Blackhawk,Toy Soldiers,https://w.wiki/3nxX
 AE5EBE,162025,United States Navy,Bell TH-57C Sea Ranger,B06,Mil,Chopper,Training Wheels,In The Navy,United States Navy,https://www.navy.mil/Resources/Fact-Files/Display-FactFiles/Article/2166684/th-57-sea-ranger-helicopter/
+AE6284,163647,United States Navy,McDonnell Douglas T-45C Goshawk,HAWK,Mil,Training Wheels,Bicycle Made For Two,L-Plate,United States Navy,https://w.wiki/6iuV
+AE62B5,165464,United States Navy,McDonnell Douglas T-45C Goshawk,HAWK,Mil,Training Wheels,Bicycle Made For Two,L-Plate,United States Navy,https://w.wiki/6iuV
+AE62D1,165495,United States Navy,McDonnell Douglas T-45C Goshawk,HAWK,Mil,Training Wheels,Bicycle Made For Two,L-Plate,United States Navy,https://w.wiki/6iuV
+AE62D5,165598,United States Navy,McDonnell Douglas T-45C Goshawk,HAWK,Mil,Training Wheels,Bicycle Made For Two,L-Plate,United States Navy,https://w.wiki/6iuV
+AE62E5,165614,United States Navy,McDonnell Douglas T-45C Goshawk,HAWK,Mil,Training Wheels,Bicycle Made For Two,L-Plate,United States Navy,https://w.wiki/6iuV
+AE62F8,165634,United States Navy,McDonnell Douglas T-45C Goshawk,HAWK,Mil,Training Wheels,Bicycle Made For Two,L-Plate,United States Navy,https://w.wiki/6iuV

--- a/plane-alert-db.csv
+++ b/plane-alert-db.csv
@@ -4870,7 +4870,7 @@ A88D5B,N650GL,Leonid Mikhelson,Gulfstream G650,GLF6,Civ,Oligarch,Dirty Money,Dis
 0A401B,7T-WHD,Algerian Air Force,C-130J-30 Super Hercules,C30J,Mil,Cargo,Tactical Airlift,Matsharfeen,Other Air Forces,https://en.wikipedia.org/wiki/Algerian_Air_Force
 0A400E,7T-WHO,Algerian Air Force,C-130J-30 Super Hercules,C30J,Mil,Cargo,Tactical Airlift,Matsharfeen,Other Air Forces,https://en.wikipedia.org/wiki/Algerian_Air_Force
 0A400D,7T-WHN,Algerian Air Force,C-130J-30 Super Hercules,C30J,Mil,Cargo,Tactical Airlift,Matsharfeen,Other Air Forces,https://en.wikipedia.org/wiki/Algerian_Air_Force
-342308,7T-WGE,Algerian Air Force,CASA C-295 M,C295,Mil,Cargo,Tactical Airlift,Matsharfeen,Other Air Forces,https://en.wikipedia.org/wiki/EADS_CASA_C-295
+342308,7T-WGE,Algerian Air Force,CASA C-295 M,C295,Mil,Cargo,Tactical Airlift,Matsharfeen,Other Air Forces,https://w.wiki/8pa2
 0A4026,7T-WIU,Algerian Air Force,Ilyushin IL-76TD,IL76,Civ,Cargo,Chonky Boy,Tail Gunner,Other Air Forces,https://en.wikipedia.org/wiki/Ilyushin_Il-76
 0A4022,7T-WID,Algerian Air Force,Ilyushin IL-76TD,IL76,Civ,Cargo,Chonky Boy,Tail Gunner,Other Air Forces,https://en.wikipedia.org/wiki/Ilyushin_Il-76
 0A4024,7T-WIG,Algerian Air Force,Ilyushin IL-76TD,IL76,Mil,Cargo,Chonky Boy,Tail Gunner,Other Air Forces,https://en.wikipedia.org/wiki/Algerian_Air_Force
@@ -5070,7 +5070,7 @@ E49210,2853,Brazilian Air Force,Embraer KC-390,KC39,Mil,Cargo,Tactical Airlift,M
 7A425F,11155,Chinese Air Force,Xian Y-20 A,Y20,Mil,Military Transport,Kunpeng,PLAAF,Other Air Forces,https://w.wiki/4meN
 7A426E,11159,Chinese Air Force,Xian Y-20 A,Y20,Mil,Military Transport,Kunpeng,PLAAF,Other Air Forces,https://w.wiki/4meN
 7AA30B,B-4074,Chinese Air Force,Xian Y-7G,AN24,Mil,Military Transport,Kunpeng,PLAAF,Other Air Forces,https://w.wiki/4meN
-000004,FAC1282,Colombian Air Force,CASA C-295 M,C295,Mil,Cargo,Tactical Transport,Marching Powder,Other Air Forces,https://en.wikipedia.org/wiki/EADS_CASA_C-295
+000004,FAC1282,Colombian Air Force,CASA C-295 M,C295,Mil,Cargo,Tactical Transport,Marching Powder,Other Air Forces,https://w.wiki/8pa2
 501F8F,223,Croatian Air Force,Mil Mi-17-1Sh,MI8,Mil,Military Transport,Search And Rescue,Hip,Other Air Forces,https://w.wiki/4mdB
 4C8080,701,Cyprus Air Force,AgustaWestland AW.139,A139,Mil,Maritime Patrol,Search And Rescue,Mae West,Other Air Forces,https://w.wiki/4mdN
 4C8081,702,Cyprus Air Force,AgustaWestland AW.139,A139,Mil,Maritime Patrol,Search And Rescue,Mae West,Other Air Forces,https://w.wiki/4mdN
@@ -13594,3 +13594,4 @@ AE62D1,165495,United States Navy,McDonnell Douglas T-45C Goshawk,HAWK,Mil,Traini
 AE62D5,165598,United States Navy,McDonnell Douglas T-45C Goshawk,HAWK,Mil,Training Wheels,Bicycle Made For Two,L-Plate,United States Navy,https://w.wiki/6iuV
 AE62E5,165614,United States Navy,McDonnell Douglas T-45C Goshawk,HAWK,Mil,Training Wheels,Bicycle Made For Two,L-Plate,United States Navy,https://w.wiki/6iuV
 AE62F8,165634,United States Navy,McDonnell Douglas T-45C Goshawk,HAWK,Mil,Training Wheels,Bicycle Made For Two,L-Plate,United States Navy,https://w.wiki/6iuV
+4CA420,285,Irish Air Corps,CASA C-295 M,C295,Mil,Cargo,Tactical Airlift,Watchful and Loyal,Other Air Forces,https://w.wiki/8pa2

--- a/plane_images.csv
+++ b/plane_images.csv
@@ -13622,3 +13622,9 @@ ADFDD0,https://cdn.jetphotos.com/full/6/32487_1520291689.jpg,https://cdn.jetphot
 080010,https://cdn.jetphotos.com/full/5/18718_1643816131.jpg,https://cdn.jetphotos.com/full/1/55509_1221513404.jpg,,
 AE483A,https://live.staticflickr.com/3414/4576536139_ce900e1a84_h.jpg,,,
 AE5EBE,https://cdn.jetphotos.com/full/2/54780_1171310155.jpg,,,
+AE6284,https://cdn.jetphotos.com/400/5/95834_1578249693.jpg,,,
+AE62B5,https://cdn.jetphotos.com/400/6/39418_1661815277.jpg,https://cdn.jetphotos.com/400/6/91133_1633458674.jpg,https://cdn.jetphotos.com/400/6/19693_1488329866.jpg,https://cdn.jetphotos.com/400/5/30075_1422767316.jpg
+AE62D1,https://cdn.jetphotos.com/400/6/53970_1425709770.jpg,https://cdn.jetphotos.com/400/4/67516_1333427663.jpg,https://cdn.jetphotos.com/400/1/82019_1173455873.jpg,
+AE62D5,https://cdn.jetphotos.com/400/5/49721_1636688440.jpg,https://cdn.jetphotos.com/400/5/55849_1562035183.jpg,https://cdn.jetphotos.com/400/4/18310_1316235076.jpg,
+AE62E5,,,,
+AE62F8,https://cdn.jetphotos.com/400/3/27557_1358016652.jpg,https://cdn.jetphotos.com/400/4/83436_1336058038.jpg,https://cdn.jetphotos.com/400/4/44329_1321516111.jpg,https://cdn.jetphotos.com/400/4/82702_1321516011.jpg

--- a/plane_images.csv
+++ b/plane_images.csv
@@ -13497,7 +13497,6 @@ AE212D,https://cdn.jetphotos.com/full/6/56176_1618540236.jpg,https://www.airport
 AE08F8,https://cdn.jetphotos.com/full/6/468870_1677176988.jpg,https://www.airport-data.com/images/aircraft/001/591/001591167.jpg,https://www.airport-data.com/images/aircraft/000/087/087882.jpg,https://www.airport-data.com/images/aircraft/001/741/001741315.jpg
 ADFEDE,https://cdn.jetphotos.com/full/5/1124507_1677470689.jpg,https://cdn.jetphotos.com/full/6/85687_1556321194.jpg,https://cdn.jetphotos.com/full/5/45507_1635887305.jpg,https://cdn.jetphotos.com/full/5/16644_1507399547.jpg
 AE0997,https://www.airport-data.com/images/aircraft/001/086/001086032.jpg,https://www.airport-data.com/images/aircraft/001/485/001485504.jpg,https://www.airport-data.com/images/aircraft/001/086/001086033.jpg,https://www.airport-data.com/images/aircraft/001/062/001062699.jpg
-AE6284,,,,
 AE6813,,,,
 AE6407,https://live.staticflickr.com/65535/49031685791_b75c962e84_k.jpg,https://live.staticflickr.com/65535/53195373291_81eb297009_k.jpg,https://cdn.jetphotos.com/full/5/54789_1571698519.jpg,https://www.airhistory.net/photos/0286891.jpg
 AE6401,https://cdn.jetphotos.com/full/6/547679_1695679069.jpg,https://cdn.jetphotos.com/full/5/19211_1572439046.jpg,https://live.staticflickr.com/2547/4055813453_d9a8b82246_k.jpg,https://live.staticflickr.com/7256/7702160774_d81bc69532_k.jpg


### PR DESCRIPTION
## Describe your changes

T-45 Hawks, most with pics
AE6284
AE62B5
AE62D1
AE62D5
AE62E5
AE62F8

From RB's last few days of hits.

AE6284 was in the database as a P-8 tactical, but looking back through August all I'm seeing it as is the Hawk, which given where it's been, what it's been doing, and the [callsign it's been using](https://henney.com/chm/callsign.htm) (BLZR, VT-21/VT-22 out of NAS Kingsville) is probably correct. I didn't see the hex appear anywhere Poseidony.

## Checklist before requesting a review

- [🦅] I have performed a self-review of my code.
- [🐱‍🐉] While waiting for someone to review your request, please help review [another open pull request](https://github.com/sdr-enthusiasts/plane-alert-db/pulls) to support the maintainers.
