### PR TITLE
Add a GAF C130, 55+02 and photos

### DIFF
--- a/plane-alert-db.csv
+++ b/plane-alert-db.csv
@@ -2440,6 +2440,7 @@ $ICAO,$Registration,$Operator,$Type,$ICAO Type,#CMPG,$Tag 1,$#Tag 2,$#Tag 3,Cate
 3E477E,D-ISGS,SVEGE Flight Inspection,AP68TP-600 Viator,VTOR,Civ,Fight Calibration,Measuring Stick,Trundle Wheel,Ptolemy would be proud,https://www.svege.de/about-us.html
 3E4AEB,D-ITOL,AVT Airborne Sensing,Cessna T303 Crusader,C303,Civ,Aerial Survey,Measuring Stick,Trundle Wheel,Ptolemy would be proud,https://www.avt.at/avt-group/avt-airborne-sensing
 3E5176,D-IWAW,AVT Airborne Sensing,B200 Super King Air,BE20,Civ,Aerial Survey,Measuring Stick,Trundle Wheel,Ptolemy would be proud,https://www.avt.at/avt-group/avt-airborne-sensing
+3E80DF,55+02,German Air Force,C-130J-30 Super Hercules,C30J,Mil,Luftbrucke,Cargo,Luftwaffe,GAF,https://www.bundeswehr.de/de/organisation/luftwaffe
 3E819E,43+29,German Air Force,Panavia Tornado IDS,TOR,Mil,Danger Zone,Swing Wing,Luftwaffe,GAF,http://torinak.com/qaop#!tll
 3E826F,54+15,German Air Force,Airbus Military A400M Atlas C1,A400,Mil,Luftbrucke,Cargo,Luftwaffe,GAF,https://www.bundeswehr.de/de/organisation/luftwaffe
 3E8525,31+47,German Air Force,Eurofighter Typhoon,EUFI,Mil,Delta Wing,Danger Zone,Luftwaffe,GAF,https://www.bundeswehr.de/de/organisation/luftwaffe

--- a/plane_images.csv
+++ b/plane_images.csv
@@ -2440,6 +2440,7 @@ $ICAO,#ImageLink,#ImageLink2,#ImageLink3,#ImageLink4
 3E477E,https://cdn.jetphotos.com/full/5/98232_1621937052.jpg,https://cdn.jetphotos.com/full/5/72664_1621547055.jpg,https://cdn.jetphotos.com/full/5/44526_1619482545.jpg,
 3E4AEB,https://cdn.jetphotos.com/full/6/80701_1601412147.jpg,https://cdn.jetphotos.com/full/5/51586_1592915269.jpg,https://cdn.jetphotos.com/full/6/32819_1539812164.jpg,
 3E5176,https://cdn.jetphotos.com/full/6/19678_1634241461.jpg,https://cdn.jetphotos.com/full/5/75692_1628601030.jpg,https://cdn.jetphotos.com/full/5/78144_1619638859.jpg,
+3E80DF,https://cdn.plnspttrs.net/11855/5502-luftwaffe-german-air-force-lockheed-martin-c-130j-30-hercules_PlanespottersNet_1447530_4f3501e5fe_o.jpg,https://cdn.plnspttrs.net/17983/5502-luftwaffe-german-air-force-lockheed-martin-c-130j-30-hercules_PlanespottersNet_1469116_30604ae43d_o.jpg,https://cdn.plnspttrs.net/45631/5502-luftwaffe-german-air-force-lockheed-martin-c-130j-30-hercules_PlanespottersNet_1302821_fdbaccedfc_o.jpg,
 3E819E,,,,
 3E826F,https://cdn.jetphotos.com/full/6/34492_1608805198.jpg,https://cdn.jetphotos.com/full/6/96168_1586638232.jpg,https://cdn.jetphotos.com/full/6/44310_1585816929.jpg,
 3E8525,https://cdn.jetphotos.com/full/6/38009_1638045960.jpg,https://cdn.jetphotos.com/full/5/54172_1564755544.jpg,https://cdn.jetphotos.com/full/6/61214_1598811951.jpg,


### PR DESCRIPTION
## Describe your changes

PLANE INFO: Added a GAF C-130. It flew south of my station in Munster, Ireland and I didn't get an alert, so I figured I should add it. Info from:

https://www.planespotters.net/photo/1302821/5502-luftwaffe-german-air-force-lockheed-martin-c-130j-30-hercules

https://www.ads-b.nl/index.php?pageno=1002


## Checklist before requesting a review

- [ x] I have performed a self-review of my code.
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/sdr-enthusiasts/plane-alert-db/pulls) to support the maintainers.
