### PR TITLE
add ae6357 ae6d75 ae0e1e 924924

### DIFF
--- a/plane-alert-db.csv
+++ b/plane-alert-db.csv
@@ -13679,3 +13679,7 @@ E90E07,CX-MIA,Uruguay Police,Robinson R44,R44,Pol,Police Squad,Policia,Copper Ch
 E90E0E,CX-MIE,Uruguay Police,Robinson R66,R66,Pol,Police Squad,Policia,Copper Chopper,Police Forces,https://en.wikipedia.org/wiki/National_Police_of_Uruguay
 E940FA,FAB-001,Gov of Bolivia,Dassault Falcon 900EX,F900,Gov,Government,Must Be Nice,Free And Fair Elections,Dictator Alert,https://en.wikipedia.org/wiki/Politics_of_Bolivia
 E940FB,FAB-002,Gov of Bolivia,Dassault Falcon 50,FA50,Gov,Government,Must Be Nice,Free And Fair Elections,Dictator Alert,https://en.wikipedia.org/wiki/Politics_of_Bolivia
+AE6357,22-72479,United States Army,Airbus Helicopters UH-72B Lakota,EC45,Mil,Air Cavalry,Chopper,Light Utility,Toy Soldiers,https://w.wiki/8k4B
+AE6D75,21-7002,USAF,Boeing-Saab T-7 Red Hawk,BT7,Mil,Training Wheels,Bicycle Made For Two,That New Plane Smell,USAF,https://w.wiki/7y3F
+AE0E1E,84-23970,United States Army,Sikorsky UH-60L Blackhawk,H60,Mil,Get To The Choppa,Military Transport,Blackhawk,Toy Soldiers,https://w.wiki/3nxX
+924924,????,United States Navy,McDonnell Douglas T-45C Goshawk,HAWK,Mil,Training Wheels,Bicycle Made For Two,Obvious Miscode,United States Navy,https://w.wiki/6iuV

--- a/plane_images.csv
+++ b/plane_images.csv
@@ -13712,3 +13712,5 @@ E90E07,https://cdn.jetphotos.com/full/5/11822_1633572716.jpg,https://cdn.jetphot
 E90E0E,https://cdn.jetphotos.com/full/6/83659_1609718717.jpg,https://cdn.jetphotos.com/full/6/16487_1581699816.jpg,,
 E940FA,https://cdn.jetphotos.com/full/5/81662_1640799003.jpg,https://cdn.jetphotos.com/full/5/81662_1640799003.jpg,https://cdn.jetphotos.com/full/5/54171_1638554504.jpg,
 E940FB,https://cdn.jetphotos.com/full/6/55153_1575059321.jpg,https://cdn.jetphotos.com/full/5/83758_1487098979.jpg,https://cdn.jetphotos.com/full/5/17432_1487090281.jpg,
+AE0E1E,https://www.planepictures.net/a/100/12/1291788328.jpg,,,
+AE6D75,https://live.staticflickr.com/65535/53322158594_72efffb18e_h.jpg,https://live.staticflickr.com/65535/53445613659_b18a131090_h.jpg,,


### PR DESCRIPTION
## Describe your changes

ae6357 - new lakota, no pics
ae6d75 - first t-7 in the database
ae0e1e - old blackhawk. very little info on this one, probably alabamer national guard, assuming it was upgraded to L model
924924 - a Goshawk. Some other planes were using this a few years back but this T-45 out of pensacola is the only one recently, I've seen it several times. Always rocks the ROKT callsign

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/sdr-enthusiasts/plane-alert-db/pulls) to support the maintainers.
