### PR TITLE
Update PPG plane to be paints, not government of Tanzania

### DIFF
--- a/plane-alert-db.csv
+++ b/plane-alert-db.csv
@@ -8928,7 +8928,7 @@ ABBECF,N856NA,NASA,AeromotAMT-200S TG-14A Super Ximango,RF10,Gov,SCE To Aux,Moto
 ABBF4C,N856TA,Top Aces Inc,General Dynamics F-16A Netz,F16,Civ,Aggressor Squadron,Callsign Viper,Broke The Hard Deck,Hired Gun,https://www.topaces.com
 ABBFA4,N856WP,Private,DHC-1 Chipmunk 22,DHC1,Civ,Air Experience Flight,Jump Johnny Jump,Air Training Corps,Jump Johnny Jump,https://youtu.be/JMz_gONS8X0
 ABC123,HR-3604,Indonesian Air Force,Eurocopter AS365 N3 Dauphin,AS65,Mil,Military Transport,Chopper,Wings Of The Motherland,Other Air Forces,https://w.wiki/4mjV
-ABC1F0,N857GA,PPG Industries Inc,Gulfstream G550,GLF5,Gov,Tanzania,Samia Suluhu Hassan,Government,Governments,https://www.tanzania.go.tz
+ABC1F0,N857GA,PPG Industries Inc,Gulfstream G550,GLF5,Civ,PPG Paints,You’d think it’d have a custom livery,Corp,Bizjets,https://www.ppg.com/
 ABC21D,N857HW,Memphis Medical Center Air Ambulance,Eurocopter EC130 T2,EC30,Civ,Air Ambo,Medical Evac,Saving Lives,Flying Doctors,https://www.hospitalwing.com/hospwing/
 ABC2FB,N857ST,Seminole Tribe of Florida,Gulfstream G-IV,GLF4,Civ,The Gambler,The House Always Wins,Snake Eyes,As Seen on TV,https://www.seminolehardrockhollywood.com/
 ABC303,N857TA,Top Aces Inc,General Dynamics F-16A Netz,F16,Civ,Aggressor Squadron,Callsign Viper,Broke The Hard Deck,Hired Gun,https://www.topaces.com


### PR DESCRIPTION
## Describe your changes

Looking at the FAA registration for this plane, it looks like it's registered to PPG.  Which is a paint company, not the Government of Tanzania.  This switches the fields to make it a bizjet but certainly change the tags or whatnot to something more creative :).  

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/sdr-enthusiasts/plane-alert-db/pulls) to support the maintainers.
