### PR TITLE
removed several crashed Hunters, added some more that weren't in the …

### DIFF
--- a/plane-alert-db.csv
+++ b/plane-alert-db.csv
@@ -13738,3 +13738,4 @@ A3C889,N343AX,Airborne Tactical Advantage,Hawker Hunter F.58,HUNT,Civ,Aggressor 
 A3CFF7,N345AX,Airborne Tactical Advantage,Hawker Hunter F.58A,HUNT,Civ,Aggressor Squadron,Callsign Viper,Broke The Hard Deck,Hired Gun,https://atacusa.com/
 A3D765,N347AX,South America Tactical & Airborne Consulting,Hawker Hunter FGA.9,HUNT,Civ,Aggressor Squadron,Callsign Viper,Broke The Hard Deck,Hired Gun,https://w.wiki/9JE4
 A3E4E3,N350AX,Airborne Tactical Advantage,Armstrong Whitworth Hunter F.6A,HUNT,Civ,Aggressor Squadron,Callsign Viper,Broke The Hard Deck,Hired Gun,https://atacusa.com/
+71F010,230925,Republic of Korea Navy,Boeing P-8A Poseidon,P8,Mil,One Ping Only Vasily,Maritime Patrol,Anti-Submarine Warfare,Other Navies,https://www.navy.mil.kr/mbshome/mbs/eng/index.do

--- a/plane-alert-db.csv
+++ b/plane-alert-db.csv
@@ -7709,7 +7709,6 @@ A389DE,N327RX,CVS Pharmacy,Dassault Falcon 2000LXS,F2TH,Civ,Pharmacy,Tylenol,Dru
 A38A05,N327TL,Thomas H Lee,Gulfstream G400SP,GLF4,Civ,Aaaaaaaand its gone,Bunch of Bankers,Scrooge McDuck,As Seen on TV,https://w.wiki/4wop
 A38C1E,N328AX,Airborne Tactical Advantage,Hawker Hunter Mk58,HUNT,Civ,Aggressor Squadron,Callsign Viper,Broke The Hard Deck,Hired Gun,https://atacusa.com/
 A38F32,N3286,Private,North American SNJ-5 Texan,T6,Civ,Training Wheels,Advanced Trainer,I Am Old,Historic,https://en.wikipedia.org/wiki/North_American_T-6_Texan
-A38FD5,N329AX,Airborne Tactical Advantage,Hawker Hunter Mk58,HUNT,Civ,Aggressor Squadron,Callsign Viper,Broke The Hard Deck,Hired Gun,https://atacusa.com/
 A3910C,N329PH,PHI Health,Eurocopter EC135 P2,EC35,Civ,Air Ambo,Medical Evac,Saving Lives,Flying Doctors,https://www.phiairmedical.com/
 A3939F,N33BR,Private,DHC-1 Chipmunk 1B-2-S3,DHC1,Civ,Air Experience Flight,Jump Johnny Jump,Air Training Corps,Jump Johnny Jump,https://youtu.be/JMz_gONS8X0
 A3942B,N33HF,HALO-Flight Inc,Bell 407,B407,Civ,Air Ambo,Medical Evac,Saving Lives,Flying Doctors,https://haloflight.org/
@@ -7720,7 +7719,6 @@ A3999C,N331AX,Airborne Tactical Advantage,Hawker Hunter Mk58,HUNT,Civ,Aggressor 
 A399B0,N331BS,B & S Air Inc,Air Tractor AT-802A,AT8T,Civ,Flying Fire Extinguisher,Air Attack,Wildfire,Aerial Firefighter,https://en.wikipedia.org/wiki/Air_Tractor_AT-802
 A399C3,N331CL,Massachusetts Institute Of Technology,Saab 340B,SF34,Civ,Flying Classroom,Vomit Comet,Students,Dogs with Jobs,https://www.mit.edu
 A39D3F,N332AB,Kansas City Police Dept,Hughes OH-6A Cayuse,H500,Pol,Police Squad,The Cops,Copper Chopper,Police Forces,https://www.kcpd.org
-A39D53,N334AX,Airborne Tactical Advantage,Hawker Hunter Mk58,HUNT,Civ,Aggressor Squadron,Callsign Viper,Broke The Hard Deck,Hired Gun,https://atacusa.com/
 A39DFD,N332HS,Private,DHC-1 Chipmunk 1B-2-S5,DHC1,Civ,Air Experience Flight,Jump Johnny Jump,Air Training Corps,Jump Johnny Jump,https://youtu.be/JMz_gONS8X0
 A39E8A,N332PH,PHI Health,Eurocopter EC135 P2+,EC35,Civ,Air Ambo,Medical Evac,Saving Lives,Flying Doctors,https://www.phiairmedical.com/
 A3A280,N333RW,Lone Star Flight Museum,North American B-25N Mitchell,B25,Civ,Bomber,WW2,Special Delivery,Historic,https://w.wiki/7o3m
@@ -7734,7 +7732,6 @@ A3AC7F,N336EB,J C Flowers & Co LLC,Gulfstream G550,GLF5,Civ,Aaaaaaaand its gone,
 A3AD24,N336LS,Las Vegas Sands Corp,Gulfstream G550,GLF5,Civ,The Gambler,Snake Eyes,House Always Wins,As Seen on TV,https://youtu.be/TRfk2RRoLRY
 A3B0DB,N337LS,Las Vegas Sands Corp,Gulfstream G550,GLF5,Civ,The Gambler,Snake Eyes,House Always Wins,As Seen on TV,https://youtu.be/iQlEt_sQa3c
 A3B11D,N337PH,PHI Health,Eurocopter EC135 P2+,EC35,Civ,Air Ambo,Medical Evac,Saving Lives,Flying Doctors,https://www.phiairmedical.com/
-A3B39D,N338AX,Airborne Tactical Advantage,Hawker Hunter Mk58,HUNT,Civ,Aggressor Squadron,Callsign Viper,Broke The Hard Deck,Hired Gun,https://atacusa.com/
 A3B492,N338LS,Las Vegas Sands Corp,Gulfstream G550,GLF5,Civ,The Gambler,Snake Eyes,House Always Wins,As Seen on TV,https://youtu.be/BoKEPcXQP8E
 A3B754,N339AX,Airborne Tactical Advantage,Hawker Hunter Mk58,HUNT,Civ,Aggressor Squadron,Callsign Viper,Broke The Hard Deck,Hired Gun,https://atacusa.com/
 A3B849,N339LS,Las Vegas Sands Corp,Gulfstream G550,GLF5,Civ,The Gambler,Snake Eyes,House Always Wins,As Seen on TV,https://youtu.be/0KDnaVZqbf8
@@ -13733,3 +13730,11 @@ E90E07,CX-MIA,Uruguay Police,Robinson R44,R44,Pol,Police Squad,Policia,Copper Ch
 E90E0E,CX-MIE,Uruguay Police,Robinson R66,R66,Pol,Police Squad,Policia,Copper Chopper,Police Forces,https://en.wikipedia.org/wiki/National_Police_of_Uruguay
 E940FA,FAB-001,Gov of Bolivia,Dassault Falcon 900EX,F900,Gov,Government,Must Be Nice,Free And Fair Elections,Dictator Alert,https://en.wikipedia.org/wiki/Politics_of_Bolivia
 E940FB,FAB-002,Gov of Bolivia,Dassault Falcon 50,FA50,Gov,Government,Must Be Nice,Free And Fair Elections,Dictator Alert,https://en.wikipedia.org/wiki/Politics_of_Bolivia
+A3721D,N321AX,Airborne Tactical Advantage,Hawker Hunter F.58,HUNT,Civ,Aggressor Squadron,Callsign Viper,Broke The Hard Deck,Hired Gun,https://atacusa.com/
+A37D42,N324AX,Airborne Tactical Advantage,Hawker Hunter F.58,HUNT,Civ,Aggressor Squadron,Callsign Viper,Broke The Hard Deck,Hired Gun,https://atacusa.com/
+A38867,N327AX,Airborne Tactical Advantage,Hawker Hunter F.58A,HUNT,Civ,Aggressor Squadron,Callsign Viper,Broke The Hard Deck,Hired Gun,https://atacusa.com/
+A3A4C1,N334AX,Airborne Tactical Advantage,Hawker Hunter F.58,HUNT,Civ,Aggressor Squadron,Callsign Viper,Broke The Hard Deck,Hired Gun,https://atacusa.com/
+A3C889,N343AX,Airborne Tactical Advantage,Hawker Hunter F.58,HUNT,Civ,Aggressor Squadron,Callsign Viper,Broke The Hard Deck,Hired Gun,https://atacusa.com/
+A3CFF7,N345AX,Airborne Tactical Advantage,Hawker Hunter F.58A,HUNT,Civ,Aggressor Squadron,Callsign Viper,Broke The Hard Deck,Hired Gun,https://atacusa.com/
+A3D765,N347AX,South America Tactical & Airborne Consulting,Hawker Hunter FGA.9,HUNT,Civ,Aggressor Squadron,Callsign Viper,Broke The Hard Deck,Hired Gun,https://w.wiki/9JE4
+A3E4E3,N350AX,Airborne Tactical Advantage,Armstrong Whitworth Hunter F.6A,HUNT,Civ,Aggressor Squadron,Callsign Viper,Broke The Hard Deck,Hired Gun,https://atacusa.com/


### PR DESCRIPTION
…db, and fixed n334ax's wrong hex

## Describe your changes

hunters:
several have been destroyed in crashes over the years, these have been removed.
n334ax had the wrong hex, it was actually using n332ax's hex.
added some other hunters.

Most of them have been set as ATAC, as that's what's painted on the tail and pics of them are shown on the ATAC website, but they actually seem to be owned by [Lortie Aviation](https://www.lortieaviation.com/home.aviation.htm) and just leased to ATAC. To minimize confusion I just went with ATAC in the db.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/sdr-enthusiasts/plane-alert-db/pulls) to support the maintainers.
