### PR TITLE
Correct A9C99A - Missing ICAO Type

### DIFF
--- a/plane-alert-db.csv
+++ b/plane-alert-db.csv
@@ -8710,7 +8710,7 @@ A9B67C,N725DT,Donald Trump,Cessna Citation X,C750,Civ,Bad Human,Orange Danger,Lo
 A9BAF2,N726MJ,Medway Air Ambulance,Learjet 45,LJ45,Civ,Air Ambo,Medical Evac,Saving Lives,Flying Doctors,https://www.medwayair.com/
 A9C265,N728MP,National Aircraft Leasing (DOJ),Cessna T206H Turbo Stationair,T206,Gov,US Dept Of Justice,Covert,Surveillance,Oxcart,https://www.justice.gov
 A9C52E,N729CA,National Airlines,Boeing 747 412BCF,B744,Civ,Cargo,Government Contractor,Airlift,Hired Gun,https://w.wiki/4xqx
-A9C99A,N73KG,One And A Quarter LLC,Extra EA.330 SCE,Civ,Do A Barrel Roll,High G,Aerobatics,Joe Cool,https://w.wiki/4nF6,
+A9C99A,N73KG,One And A Quarter LLC,Extra EA-300SC,E300,Civ,Do A Barrel Roll,High G,Aerobatics,Joe Cool,https://w.wiki/4nF6
 A9C9C5,N73M,3M Company,Gulfstream G550,GLF5,Civ,Chemicals,Mining,Sticky Tape,As Seen on TV,https://en.wikipedia.org/wiki/3M
 A9C9D0,N73ML,Celebration TV America,Bombardier Challenger 601,CL60,Civ,Jesus He Knows Me,Church Of Private Jets,Send NO Money,Jesus he Knows me,https://tinyurl.com/45p5rv7s
 A9CB4B,N730CP,Aero Air,Cessna Citation M2,C25M,Civ,Air Ambo,Medical Evac,Saving Lives,Flying Doctors,https://www.aeroair.com/


### PR DESCRIPTION
## Describe your changes
Correct A9C99A - Missing ICAO Type

Been wrong for a few months, created a new "Do a Barrel Roll" type that I just noticed.
<!-- Briefly describe the changes you made. 

NEW FEATURE: Please explain why the feature is needed.
BUG FIX: Please explain the bug and how you fixed this bug.
PLANE INFO: Please add the sources used to aid the review process.
-->

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/sdr-enthusiasts/plane-alert-db/pulls) to support the maintainers.
