### PR TITLE
Add N274AH Air Medevac

### DIFF
--- a/plane-alert-db.csv
+++ b/plane-alert-db.csv
@@ -7596,6 +7596,7 @@ A2AF86,N272SM,Reach Air Medical,AgustaWestland A.109 E Power,A109,Civ,Air Ambo,M
 A2B041,N272ZZ,Big Flats LLC,Douglas DC-3 BT-67,DC3T,Civ,Turboprop,Rejuvenated,Indestructible,Historic,https://en.wikipedia.org/wiki/Basler_BT-67
 A2B2D2,N273NE,Boston MedFlight,Eurocopter EC145,EC45,Civ,Air Ambo,Medical Evac,Saving Lives,Flying Doctors,https://www.bostonmedflight.org
 A2B320,N273RH,Janet Airlines,Boeing 737NG,B736,Gov,Area 51,Tonopah Test Range,Little Green Men,Distinctive,https://en.wikipedia.org/wiki/Janet_(airline)
+A2B560,N274AH,Charlotte Mecklenburg Hospital Authority,Pilatus PC-24,PC24,Civ,Air Ambo,Medical Evac,Saving Lives,Flying Doctors,https://atriumhealth.org/medical-services/specialty-care/other-specialty-care-services/medcenter-air/fixed-wing-critical-care-transport
 A2B573,N274BB,Lcb Leasing (DOJ),Cessna 182T Skylane,C182,Gov,US Dept Of Justice,Covert,Surveillance,Oxcart,https://www.justice.gov
 A2B6F4,N274SM,Reach Air Medical,AgustaWestland A.109 E Power,A109,Civ,Air Ambo,Medical Evac,Saving Lives,Flying Doctors,https://reachair.com/
 A2C518,N278KC,Cullman Police Dept,Hughes OH-6A Cayuse,H500,Pol,Police Squad,The Cops,Copper Chopper,Police Forces,https://cullmanal.gov/depts/cpd/


### PR DESCRIPTION
## Describe your changes

<!-- Briefly describe the changes you made. 

PLANE INFO: 
Add A2B560/N274AH Pilatus PC-24 Air Medevac
Sources:
https://www.flightaware.com/live/flight/N274AH
https://www.flightradar24.com/data/aircraft/n274ah
https://atriumhealth.org/medical-services/specialty-care/other-specialty-care-services/medcenter-air/fixed-wing-critical-care-transport
-->

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/sdr-enthusiasts/plane-alert-db/pulls) to support the maintainers.
