### PR TITLE
fix stray USAF owner strings, change tags on USAF C-40s, another fami…

### DIFF
--- a/plane-alert-db.csv
+++ b/plane-alert-db.csv
@@ -9812,7 +9812,7 @@ AE0014,65-10396,USAF,Northrop T-38C Talon,T38,Mil,Training Wheels,Bicycle Made F
 AE0016,65-10431,USAF,Northrop T-38C Talon,T38,Mil,Training Wheels,Bicycle Made For Two,To Fly Fight And Win,USAF,https://w.wiki/7y3F
 AE0017,65-10430,USAF,Northrop T-38C Talon,T38,Mil,Training Wheels,Bicycle Made For Two,To Fly Fight And Win,USAF,https://w.wiki/7y3F
 AE001A,66-4335,USAF,Northrop T-38C Talon,T38,Mil,Training Wheels,Bicycle Made For Two,To Fly Fight And Win,USAF,https://w.wiki/7y3F
-AE001B,66-4370,United States Air Force,Northrop T-38C Talon,T38,Mil,Training Wheels,Bicycle Made For Two,To Fly Fight And Win,USAF,https://w.wiki/7y3F
+AE001B,66-4370,USAF,Northrop T-38C Talon,T38,Mil,Training Wheels,Bicycle Made For Two,To Fly Fight And Win,USAF,https://w.wiki/7y3F
 AE001E,67-14851,USAF,Northrop T-38C Talon,T38,Mil,Training Wheels,Bicycle Made For Two,To Fly Fight And Win,USAF,https://w.wiki/7y3F
 AE001F,67-14857,USAF,Northrop T-38C Talon,T38,Mil,Training Wheels,Bicycle Made For Two,To Fly Fight And Win,USAF,https://w.wiki/7y3F
 AE0021,67-14915,USAF,Northrop T-38C Talon,T38,Mil,Training Wheels,Bicycle Made For Two,To Fly Fight And Win,USAF,https://w.wiki/7y3F
@@ -9823,8 +9823,8 @@ AE002B,67-14949,USAF,Northrop T-38C Talon,T38,Mil,Training Wheels,Bicycle Made F
 AE002E,68-8102,USAF,Northrop T-38C Talon,T38,Mil,Training Wheels,Bicycle Made For Two,To Fly Fight And Win,USAF,https://w.wiki/7y3F
 AE002F,68-8110,USAF,Northrop T-38C Talon,T38,Mil,Training Wheels,Bicycle Made For Two,To Fly Fight And Win,USAF,https://w.wiki/7y3F
 AE0030,68-8117,USAF,Northrop T-38C Talon,T38,Mil,Training Wheels,Bicycle Made For Two,To Fly Fight And Win,USAF,https://w.wiki/7y3F
-AE0031,68-8130,United States Air Force,Northrop T-38C Talon,T38,Mil,Training Wheels,Bicycle Made For Two,To Fly Fight And Win,USAF,https://w.wiki/7y3F
-AE0032,68-8144,United States Air Force,Northrop T-38C Talon,T38,Mil,Training Wheels,Bicycle Made For Two,To Fly Fight And Win,USAF,https://w.wiki/7y3F
+AE0031,68-8130,USAF,Northrop T-38C Talon,T38,Mil,Training Wheels,Bicycle Made For Two,To Fly Fight And Win,USAF,https://w.wiki/7y3F
+AE0032,68-8144,USAF,Northrop T-38C Talon,T38,Mil,Training Wheels,Bicycle Made For Two,To Fly Fight And Win,USAF,https://w.wiki/7y3F
 AE0033,68-8159,USAF,Northrop T-38C Talon,T38,Mil,Training Wheels,Bicycle Made For Two,To Fly Fight And Win,USAF,https://w.wiki/7y3F
 AE0034,68-8160,USAF,Northrop T-38C Talon,T38,Mil,Training Wheels,Bicycle Made For Two,To Fly Fight And Win,USAF,https://w.wiki/7y3F
 AE0035,68-8171,USAF,Northrop T-38C Talon,T38,Mil,Training Wheels,Bicycle Made For Two,To Fly Fight And Win,USAF,https://w.wiki/7y3F
@@ -9961,7 +9961,7 @@ AE0171,84-0079,USAF,Gates C-21A,LJ35,Mil,Bizjet,Must Be Nice,To Fly Fight And Wi
 AE0175,84-0120,USAF,Gates C-21A,LJ35,Mil,Bizjet,Must Be Nice,To Fly Fight And Win,USAF,https://www.airforce.com
 AE0178,84-0129,USAF,Gates C-21A,LJ35,Mil,Bizjet,Must Be Nice,To Fly Fight And Win,USAF,https://www.airforce.com
 AE017A,84-0142,USAF,Gates C-21A,LJ35,Mil,Bizjet,Must Be Nice,To Fly Fight And Win,USAF,https://www.airforce.com
-AE0181,84-0139,United States Air Force,Gates C-21A,LJ35,Mil,Bizjet,Must Be Nice,To Fly Fight And Win,USAF,https://www.airforce.com
+AE0181,84-0139,USAF,Gates C-21A,LJ35,Mil,Bizjet,Must Be Nice,To Fly Fight And Win,USAF,https://www.airforce.com
 AE0189,84-0095,USAF,Gates C-21A,LJ35,Mil,Bizjet,Must Be Nice,To Fly Fight And Win,USAF,https://www.airforce.com
 AE018A,84-0096,USAF,Gates C-21A,LJ35,Mil,Bizjet,Must Be Nice,To Fly Fight And Win,USAF,https://www.airforce.com
 AE0191,84-0124,USAF,Gates C-21A,LJ35,Mil,Bizjet,Must Be Nice,To Fly Fight And Win,USAF,https://www.airforce.com
@@ -10924,7 +10924,7 @@ AE0941,61-2667,USAF,Boeing WC-135W,C135,Mil,mmm Neutrons,Its The End Of The Worl
 AE0942,73-1208,USAF,Beech C-12C Huron,BE20,Mil,Embassy Support,Not So VIP,Light Cargo,USAF,https://www.airforce.com
 AE0943,86-0080,USAF,Beech C-12J Huron,BE20,Mil,Embassy Support,Not So VIP,Light Cargo,USAF,https://www.airforce.com
 AE0944,76-0161,USAF,Beech C-12C Huron,BE20,Mil,Embassy Support,Not So VIP,Light Cargo,USAF,https://www.airforce.com
-AE0945,01-0040,USAF,Boeing C-40B,B737,Gov,VIP,Office In The Sky,Government,Governments,https://w.wiki/7wDu
+AE0945,01-0040,USAF,Boeing C-40B,B737,Gov,VIP,Office In The Sky,Not A Bus,Governments,https://w.wiki/7wDu
 AE0949,68-10329,USAF,Lockheed U-2S,U2,Mil,Hiiiiiigh In The Sky,Dragon Lady,Spyplane,Oxcart,https://en.wikipedia.org/wiki/Lockheed_U-2
 AE094A,68-10331,USAF,Lockheed U-2S,U2,Mil,Hiiiiiigh In The Sky,Dragon Lady,Spyplane,Oxcart,https://en.wikipedia.org/wiki/Lockheed_U-2
 AE094B,68-10336,USAF,Lockheed U-2S,U2,Mil,Hiiiiiigh In The Sky,Dragon Lady,Spyplane,Oxcart,https://en.wikipedia.org/wiki/Lockheed_U-2
@@ -11108,15 +11108,15 @@ AE1141,165975,United States Navy,Raytheon T-6B Texan II,TEX2,Mil,Training Wheels
 AE1144,165978,United States Navy,Raytheon T-6A Texan II,TEX2,Mil,Training Wheels,Bicycle Made For Two,L-Plate,United States Navy,https://www.navy.mil
 AE1146,165980,United States Navy,Raytheon T-6A Texan II,TEX2,Mil,Training Wheels,Bicycle Made For Two,L-Plate,United States Navy,https://www.navy.mil
 AE1151,165991,United States Navy,Raytheon T-6A Texan II,TEX2,Mil,Training Wheels,Bicycle Made For Two,L-Plate,United States Navy,https://www.navy.mil
-AE115D,01-0015,USAF,Boeing C-40B,B737,Gov,VIP,Office In The Sky,Government,Governments,https://w.wiki/7wDu
+AE115D,01-0015,USAF,Boeing C-40B,B737,Gov,VIP,Office In The Sky,Not A Bus,Governments,https://w.wiki/7wDu
 AE115E,01-1930,USAF,Gulfstream C-37A,GLF5,Mil,Bizjet,Must Be Nice,VIP Transport,USAF,https://www.airforce.com
 AE1160,02-1434,USAF,C-130J-30 Super Hercules,C30J,Mil,Cargo,Heavy Duty,To Fly Fight And Win,USAF,https://www.airforce.com
 AE1161,02-1463,USAF,C-130J-30 Super Hercules,C30J,Mil,Cargo,Heavy Duty,To Fly Fight And Win,USAF,https://www.airforce.com
 AE1162,02-1464,USAF,C-130J-30 Super Hercules,C30J,Mil,Cargo,Heavy Duty,To Fly Fight And Win,USAF,https://www.airforce.com
 AE1163,02-8155,USAF,C-130J-30 Super Hercules,C30J,Mil,Cargo,Heavy Duty,To Fly Fight And Win,USAF,https://www.airforce.com
 AE1164,02-0314,USAF,C-130J-30 Super Hercules,C30J,Mil,Cargo,Heavy Duty,To Fly Fight And Win,USAF,https://www.airforce.com
-AE1165,02-0201,USAF,Boeing C-40C,B737,Gov,VIP,Office In The Sky,Government,Governments,https://w.wiki/7wDu
-AE1167,02-0202,USAF,Boeing C-40C,B737,Gov,VIP,Office In The Sky,Government,Governments,https://w.wiki/7wDu
+AE1165,02-0201,USAF,Boeing C-40C,B737,Gov,VIP,Office In The Sky,Not A Bus,Governments,https://w.wiki/7wDu
+AE1167,02-0202,USAF,Boeing C-40C,B737,Gov,VIP,Office In The Sky,Not A Bus,Governments,https://w.wiki/7wDu
 AE116A,84-00166,United States Army,Beech C-12U-3 Huron,BE20,Mil,Embassy Support,Not So VIP,Light Cargo,Toy Soldiers,https://w.wiki/8p9A
 AE116C,84-00168,United States Army,Beech C-12U Huron,BE20,Mil,Embassy Support,Not So VIP,Light Cargo,Toy Soldiers,https://w.wiki/8p9A
 AE116E,84-00177,United States Army,Beech C-12U Huron,BE20,Mil,Embassy Support,Not So VIP,Light Cargo,Toy Soldiers,https://w.wiki/8p9A
@@ -11218,10 +11218,10 @@ AE11EE,81-0005,USAF,Boeing E-3G Sentry,E3TF,Mil,Eye In The Sky,AWACS,Airborne Ea
 AE11EF,82-0006,USAF,Boeing E-3C Sentry,E3TF,Mil,Eye In The Sky,AWACS,Airborne Early Warning,Oxcart,https://en.wikipedia.org/wiki/Boeing_E-3_Sentry
 AE11F0,82-0007,USAF,Boeing E-3G Sentry,E3TF,Mil,Eye In The Sky,AWACS,Airborne Early Warning,Oxcart,https://en.wikipedia.org/wiki/Boeing_E-3_Sentry
 AE11F2,83-0009,USAF,Boeing E-3C Sentry,E3TF,Mil,Eye In The Sky,AWACS,Airborne Early Warning,Oxcart,https://en.wikipedia.org/wiki/Boeing_E-3_Sentry
-AE11F6,01-1941,USAF,Boeing C-40B,B737,Gov,VIP,Office In The Sky,Government,Governments,https://w.wiki/7wDu
-AE11F7,01-0041,USAF,Boeing C-40B,B737,Gov,VIP,Office In The Sky,Government,Governments,https://w.wiki/7wDu
-AE11F8,02-0042,USAF,Boeing C-40B,B737,Gov,VIP,Office In The Sky,Government,Governments,https://w.wiki/7wDu
-AE11FA,02-0203,USAF,Boeing C-40C,B737,Gov,VIP,Office In The Sky,Government,Governments,https://w.wiki/7wDu
+AE11F6,01-1941,USAF,Boeing C-40B,B737,Gov,VIP,Office In The Sky,Not A Bus,Governments,https://w.wiki/7wDu
+AE11F7,01-0041,USAF,Boeing C-40B,B737,Gov,VIP,Office In The Sky,Not A Bus,Governments,https://w.wiki/7wDu
+AE11F8,02-0042,USAF,Boeing C-40B,B737,Gov,VIP,Office In The Sky,Not A Bus,Governments,https://w.wiki/7wDu
+AE11FA,02-0203,USAF,Boeing C-40C,B737,Gov,VIP,Office In The Sky,Not A Bus,Governments,https://w.wiki/7wDu
 AE11FE,07-72009,United States Army,Eurocopter UH-72A Lakota,EC45,Mil,Air Cavalry,Chopper,Light Utility,Toy Soldiers,https://w.wiki/8k4B
 AE1200,89-00268,United States Army,Beech RC-12N Huron,BE20,Mil,Guardrail,SIGINT,Aerials Galore,Oxcart,https://w.wiki/8p9R
 AE1201,89-00269,United States Army,Beech RC-12N Huron,BE20,Mil,Guardrail,SIGINT,Aerials Galore,Oxcart,https://w.wiki/8p9R
@@ -11683,14 +11683,14 @@ AE17BB,98-0131,USAF,F-15E Eagle,F15,Mil,USAF,Multi Role,Strike Eagle,USAF,https:
 AE17BD,98-0133,USAF,F-15E Eagle,F15,Mil,USAF,Multi Role,Strike Eagle,USAF,https://w.wiki/3qBi
 AE17BE,98-0134,USAF,F-15E Eagle,F15,Mil,USAF,Multi Role,Strike Eagle,USAF,https://w.wiki/3qBi
 AE17BF,98-0135,USAF,F-15E Eagle,F15,Mil,USAF,Multi Role,Strike Eagle,USAF,https://w.wiki/3qBi
-AE17EF,05-0730,USAF,Boeing C-40C,B737,Gov,VIP,Office In The Sky,Government,Governments,https://w.wiki/7wDu
+AE17EF,05-0730,USAF,Boeing C-40C,B737,Gov,VIP,Office In The Sky,Not A Bus,Governments,https://w.wiki/7wDu
 AE1817,167806,United States Marine Corps,Bell Textron UH-1Y Venom,SUCO,Mil,Chopper,Gunship,Semper Fidelis,United States Marine Corps,https://www.marines.mil/
 AE1818,167807,United States Marine Corps,Bell Textron UH-1Y Venom,SUCO,Mil,Chopper,Gunship,Semper Fidelis,United States Marine Corps,https://www.marines.mil/
 AE1827,00-26868,United States Army,Sikorsky UH-60L Black Hawk,H60,Mil,Get To The Choppa,Military Transport,Blackhawk,Toy Soldiers,https://w.wiki/3nxX
 AE1849,71-20167,USAF,Bell TH-1H Iroquois,UH1,Mil,Huey,Get To The Choppa,To Fly Fight And Win,USAF,https://youtu.be/M4nFSdNNFQw
 AE1899,06-72001,United States Army,Eurocopter UH-72A Lakota,EC45,Mil,Air Cavalry,Chopper,Light Utility,Toy Soldiers,https://w.wiki/8k4B
-AE189A,05-4613,USAF,Boeing C-40C,B737,Gov,VIP,Office In The Sky,Government,Governments,https://w.wiki/7wDu
-AE189C,05-0932,USAF,Boeing C-40C,B737,Gov,VIP,Office In The Sky,Government,Governments,https://w.wiki/7wDu
+AE189A,05-4613,USAF,Boeing C-40C,B737,Gov,VIP,Office In The Sky,Not A Bus,Governments,https://w.wiki/7wDu
+AE189C,05-0932,USAF,Boeing C-40C,B737,Gov,VIP,Office In The Sky,Not A Bus,Governments,https://w.wiki/7wDu
 AE18AC,78-0582,USAF,A-10 Thunderbolt II,A10,Mil,Warthog,Brrrrrrrrrrrrrrrrrrrrrrt,Run Away,Gunship,https://en.wikipedia.org/wiki/Fairchild_Republic_A-10_Thunderbolt_II
 AE18AE,78-0631,USAF,A-10 Thunderbolt II,A10,Mil,Warthog,Brrrrrrrrrrrrrrrrrrrrrrt,Run Away,Gunship,https://en.wikipedia.org/wiki/Fairchild_Republic_A-10_Thunderbolt_II
 AE18B3,78-0638,USAF,A-10 Thunderbolt II,A10,Mil,Warthog,Brrrrrrrrrrrrrrrrrrrrrrt,Run Away,Gunship,https://en.wikipedia.org/wiki/Fairchild_Republic_A-10_Thunderbolt_II
@@ -12909,7 +12909,7 @@ AE4F17,10-0223,USAF,C-17A Globemaster III,C17,Mil,Tactical Airlift,Globemaster,T
 AE4FB1,168097,United States Navy,Sikorsky MH-60R Seahawk,H60,Mil,ASW,Multi Role,Sub Hunter,United States Navy,https://w.wiki/8o8Y
 AE4FB7,168103,United States Navy,Sikorsky MH-60R Seahawk,H60,Mil,ASW,Multi Role,Sub Hunter,United States Navy,https://w.wiki/8o8Y
 AE5026,167792,USAF,Bell MQ-8B,UAV,Mil,UAV,Border Patrol,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Northrop_Grumman_MQ-8_Fire_Scout
-AE503D,09-0540,USAF,Boeing C-40C,B737,Gov,VIP,Office In The Sky,Government,Governments,https://w.wiki/7wDu
+AE503D,09-0540,USAF,Boeing C-40C,B737,Gov,VIP,Office In The Sky,Not A Bus,Governments,https://w.wiki/7wDu
 AE509D,08-00263,United States Army,DHC UV-18C Twin Otter,DHC6,Mil,Perfectly Serviceable Aircraft,Skydive,Golden Knights,Aerobatic Teams,https://w.wiki/4nFV
 AE509E,08-00264,United States Army,DHC UV-18C Twin Otter,DHC6,Mil,Perfectly Serviceable Aircraft,Skydive,Golden Knights,Aerobatic Teams,https://w.wiki/4nFV
 AE50E2,10-20311,United States Army,Sikorsky UH-60M Black Hawk,H60,Mil,Get To The Choppa,Utility,Troop Transport,Toy Soldiers,https://w.wiki/3nxX
@@ -13673,7 +13673,7 @@ AF3C53,A57-001,Australian Air Force,Northrop Grumman MQ-4C Triton,Q4,Mil,UAV,Sky
 AF4A7B,168207,United States Marine Corps,UC-12W Huron,B350,Mil,USMC,Not So VIP,Semper Fidelis,United States Marine Corps,https://www.marines.mil/
 AFF009,18-20994,United States Army,Sikorsky UH-60 Black Hawk,H60,Mil,Get To The Choppa,Military Transport,Blackhawk,Toy Soldiers,https://w.wiki/3nxX
 B191D8,75-0528,USAF,Boeing E-3B Sentry,E3TF,Mil,Eye In The Sky,AWACS,Airborne Early Warning,Oxcart,https://en.wikipedia.org/wiki/Boeing_E-3_Sentry
-B648D9,09-0540,USAF,Boeing C-40C,B737,Gov,VIP,Office In The Sky,Government,Governments,https://w.wiki/7wDu
+B648D9,09-0540,USAF,Boeing C-40C,B737,Gov,VIP,Office In The Sky,Not A Bus,Governments,https://w.wiki/7wDu
 C00020,C-FABF,PAL Aerospace,Cessna Citation SII,C550,Civ,Surveillance,Covert,Spyplane,Oxcart,https://palaerospace.com/en/our-services
 C00091,C-FAFO,Province of Saskatchewan,Canadair CL-215,CL2T,Gov,Super Scooper,Air Attack,Wildfire,Aerial Firefighter,https://www.saskatchewan.ca
 C0010A,C-FAKF,Private,AutoGyro Europe Cavalon,CLON,Civ,Little Nellie,Gyrocopter,Nope Mobile,You came here in that thing?,https://youtu.be/xFozWDLne7c
@@ -14110,3 +14110,4 @@ E90E07,CX-MIA,Uruguay Police,Robinson R44,R44,Pol,Police Squad,Policia,Copper Ch
 E90E0E,CX-MIE,Uruguay Police,Robinson R66,R66,Pol,Police Squad,Policia,Copper Chopper,Police Forces,https://en.wikipedia.org/wiki/National_Police_of_Uruguay
 E940FA,FAB-001,Gov of Bolivia,Dassault Falcon 900EX,F900,Gov,Government,Must Be Nice,Free And Fair Elections,Dictator Alert,https://en.wikipedia.org/wiki/Politics_of_Bolivia
 E940FB,FAB-002,Gov of Bolivia,Dassault Falcon 50,FA50,Gov,Government,Must Be Nice,Free And Fair Elections,Dictator Alert,https://en.wikipedia.org/wiki/Politics_of_Bolivia
+A8784F,N645FD,Family Dollar,Learjet 45,LJ45,Civ,Must Be Nice,Bizjet,Just a Buck,As Seen on TV,https://w.wiki/AsJH

--- a/plane_images.csv
+++ b/plane_images.csv
@@ -14142,4 +14142,7 @@ E909FB,https://cdn.jetphotos.com/full/3/80439_1386340712.jpg,https://cdn.jetphot
 E90E07,https://cdn.jetphotos.com/full/5/11822_1633572716.jpg,https://cdn.jetphotos.com/full/5/57126_1633573621.jpg,https://cdn.jetphotos.com/full/5/32536_1540856304.jpg,
 E90E0E,https://cdn.jetphotos.com/full/6/83659_1609718717.jpg,https://cdn.jetphotos.com/full/6/16487_1581699816.jpg,,
 E940FA,https://cdn.jetphotos.com/full/5/81662_1640799003.jpg,https://cdn.jetphotos.com/full/5/81662_1640799003.jpg,https://cdn.jetphotos.com/full/5/54171_1638554504.jpg,
-N1VA,https://cdn.jetphotos.com/full/5/82798_1635173759.jpg,https://cdn.jetphotos.com/full/5/50393_1614646852.jpg,https://cdn.jetphotos.com/full/5/22213_1633834723.jpg,
+A001DE,https://cdn.jetphotos.com/full/5/82798_1635173759.jpg,https://cdn.jetphotos.com/full/5/50393_1614646852.jpg,https://cdn.jetphotos.com/full/5/22213_1633834723.jpg,
+A8784F,https://cdn.jetphotos.com/400/6/22545_1410391290.jpg,https://cdn.jetphotos.com/400/4/35858_1357055420.jpg,https://cdn.jetphotos.com/400/5/19839_1398514760.jpg,
+E940FB,https://cdn.jetphotos.com/full/6/55153_1575059321.jpg,https://cdn.jetphotos.com/full/5/83758_1487098979.jpg,https://cdn.jetphotos.com/full/5/17432_1487090281.jpg,
+A13ADC,https://photos.flightaware.com/photos/retriever/184dcbed2dddb3d85203da61e6fb064bf97ad0cd,https://photos.flightaware.com/photos/retriever/c86106dfd96154864e1236d4a1d67480e9bbbb2a,,

--- a/plane_images.csv
+++ b/plane_images.csv
@@ -7409,7 +7409,6 @@ A136FE,https://cdn.jetphotos.com/full/5/65028_1641634081.jpg,https://cdn.jetphot
 A13733,,,,
 A137FC,https://cdn.jetphotos.com/full/5/38832_1636717117.jpg,https://cdn.jetphotos.com/full/4/74070_1378725250.jpg,https://cdn.jetphotos.com/full/1/32948_1077062918.jpg,
 A13811,https://cdn.jetphotos.com/full/2/78935_1242777329.jpg,,,
-A13ADC,,,,
 A13EBD,https://cdn.jetphotos.com/full/2/64520_1046640785.jpg,,,
 A13F4E,https://cdn.jetphotos.com/full/5/40710_1530150660.jpg,https://cdn.jetphotos.com/full/2/95046_1208242911.jpg,https://cdn.jetphotos.com/full/1/56838_1109035379.jpg,
 A13F91,https://cdn.jetphotos.com/full/1/86201_1110910196.jpg,,,

--- a/plane_images.csv
+++ b/plane_images.csv
@@ -7176,7 +7176,6 @@ A00187,https://live.staticflickr.com/5573/14663281559_0980ed9b20_h.jpg,https://c
 A001B1,https://cdn.jetphotos.com/full/5/40360_1618846217.jpg,https://cdn.jetphotos.com/full/5/91975_1607721870.jpg,https://cdn.jetphotos.com/full/5/56314_1606424486.jpg,
 A001BC,https://cdn.jetphotos.com/full/5/52484_1606042478.jpg,https://cdn.jetphotos.com/full/6/42200_1592981711.jpg,https://cdn.jetphotos.com/full/5/27514_1562653530.jpg,
 A001C5,https://cdn.jetphotos.com/full/6/52914_1635278169.jpg,https://cdn.jetphotos.com/full/5/53039_1633848869.jpg,https://cdn.jetphotos.com/full/5/71966_1555683266.jpg,https://cdn.jetphotos.com/full/6/60000_1436682869.jpg
-A001DE,,,,
 A001E0,,,,
 A00212,,,,
 A0025B,,,,

--- a/scripts/create_db_derivatives.py
+++ b/scripts/create_db_derivatives.py
@@ -161,6 +161,9 @@ if __name__ == "__main__":
             extra_icao_df["_merge"] == "left_only"
         ].index.tolist()
         for item in extra_icao_df:
+            icao_to_remove = images_df.loc[item, "$ICAO"]  # Get the hex to be removed
+            logging.info(f"Removing ICAO: {icao_to_remove}") # Log it
+
             if "plane_images_df" in locals():
                 plane_images_df = plane_images_df.drop(item)
                 plane_images_df.to_csv(


### PR DESCRIPTION
…ly dollar jet, fix bad image additions from yesterday, add pics back in for E940FB which actions deleted?

## Describe your changes

* Some T-38s had owner string as 'united states air force' rather than USAF. corrected.
* changed some tags on USAF C-40s
* added a third family dollar bizjet, with pics
* images added in a PR yesterday were using reg rather than hex. corrected
* pics for E940FB were apparently deleted by the post-merge github actions. readded this
* added logging to `create_db_derivatives.py` to show the hex of anything it deletes in `plane_images.csv`, just like it shows the hexes of new additions.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/sdr-enthusiasts/plane-alert-db/pulls) to support the maintainers.
