### PR TITLE
Initial pass adding N990XB plus images

### DIFF
--- a/plane-alert-db.csv
+++ b/plane-alert-db.csv
@@ -14670,3 +14670,4 @@ E90E07,CX-MIA,Uruguay Police,Robinson R44,R44,Pol,Police Squad,Policia,Copper Ch
 E90E0E,CX-MIE,Uruguay Police,Robinson R66,R66,Pol,Police Squad,Policia,Copper Chopper,Police Forces,https://w.wiki/B3LK
 E940FA,FAB-001,Gov of Bolivia,Dassault Falcon 900EX,F900,Gov,Government,Must Be Nice,Free And Fair Elections,Dictator Alert,https://w.wiki/B3LJ
 E940FB,FAB-002,Gov of Bolivia,Dassault Falcon 50,FA50,Gov,Government,Must Be Nice,Free And Fair Elections,Dictator Alert,https://w.wiki/B3LJ
+ADD4B2,N990XB,Boom Technology,Boom XB-1,XB1,Civ,Testbed,Flight Test,OK Boomer,Distinctive,https://boomsupersonic.com/xb-1

--- a/plane_images.csv
+++ b/plane_images.csv
@@ -14670,3 +14670,4 @@ E90E07,https://cdn.jetphotos.com/full/5/11822_1633572716.jpg,https://cdn.jetphot
 E90E0E,https://cdn.jetphotos.com/full/6/83659_1609718717.jpg,https://cdn.jetphotos.com/full/6/16487_1581699816.jpg,,
 E940FA,https://cdn.jetphotos.com/full/5/81662_1640799003.jpg,https://cdn.jetphotos.com/full/5/81662_1640799003.jpg,https://cdn.jetphotos.com/full/5/54171_1638554504.jpg,
 E940FB,https://cdn.jetphotos.com/full/6/55153_1575059321.jpg,https://cdn.jetphotos.com/full/5/83758_1487098979.jpg,https://cdn.jetphotos.com/full/5/17432_1487090281.jpg,
+ADD4B2,https://boomsupersonic.com/wp-content/uploads/2024/12/xb-1-milestone-2024-12-flight-9.jpg,https://boomsupersonic.com/wp-content/uploads/2024/10/xb-1-milestone-2024-10-sixth-flight.jpg,https://boomsupersonic.com/wp-content/uploads/2024/12/xb-1-milestone-2024-12-flight-10.jpg,https://boomsupersonic.com/wp-content/uploads/2025/01/xb-1-milestone-2025-01-flight-11.jpg


### PR DESCRIPTION
## Describe your changes

PLANE INFO: Initial pass adding N990XB plus images
Sources: FAA registry, boomsupersonic.com

Guessed on the ICAO type (XB1) and tags (`OK Boomer` is something I made up) since this is pretty unique.

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/sdr-enthusiasts/plane-alert-db/pulls) to support the maintainers.
