### PR TITLE
Add new City of Phoenix Pilatus PC-12 tail number N630FB info and image

### DIFF
--- a/plane-alert-db.csv
+++ b/plane-alert-db.csv
@@ -15778,3 +15778,4 @@ E90E07,CX-MIA,Uruguay Police,Robinson R44,R44,Pol,Police Squad,Policia,Copper Ch
 E90E0E,CX-MIE,Uruguay Police,Robinson R66,R66,Pol,Police Squad,Policia,Copper Chopper,Police Forces,https://w.wiki/B3LK
 E940FA,FAB-001,Gov of Bolivia,Dassault Falcon 900EX,F900,Gov,Government,Must Be Nice,Free And Fair Elections,Dictator Alert,https://w.wiki/B3LJ
 E940FB,FAB-002,Gov of Bolivia,Dassault Falcon 50,FA50,Gov,Government,Must Be Nice,Free And Fair Elections,Dictator Alert,https://w.wiki/B3LJ
+A83E3B,N630FB,Phoenix Police Dept,Pilatus PC-12 47E,PC12,Pol,Police Squad,The Cops,Surveillance,Police Forces,https://www.phoenix.gov/police

--- a/plane_images.csv
+++ b/plane_images.csv
@@ -15778,3 +15778,4 @@ E90E07,https://cdn.jetphotos.com/full/5/11822_1633572716.jpg,https://cdn.jetphot
 E90E0E,https://cdn.jetphotos.com/full/6/83659_1609718717.jpg,https://cdn.jetphotos.com/full/6/16487_1581699816.jpg,,
 E940FA,https://cdn.jetphotos.com/full/5/81662_1640799003.jpg,https://cdn.jetphotos.com/full/5/81662_1640799003.jpg,https://cdn.jetphotos.com/full/5/54171_1638554504.jpg,
 E940FB,https://cdn.jetphotos.com/full/6/55153_1575059321.jpg,https://cdn.jetphotos.com/full/5/83758_1487098979.jpg,https://cdn.jetphotos.com/full/5/17432_1487090281.jpg,
+A83E3B,https://media.abpic.co.uk/pictures/full_size_0612/1933770-large.jpg,,,


### PR DESCRIPTION
## Describe your changes

PLANE INFO: Add Second Phoenix PD Pilatus PC-12 info and image

Source: ADS-B traffic, FAA Registry

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] While waiting for someone to review your request, please help review [another open pull request](https://github.com/sdr-enthusiasts/plane-alert-db/pulls) to support the maintainers.
