### PR TITLE
Add 87 Polish Air Force aircraft

### DIFF
--- a/plane-alert-db.csv
+++ b/plane-alert-db.csv
@@ -15996,3 +15996,90 @@ E90E07,CX-MIA,Uruguay Police,Robinson R44,R44,Pol,Police Squad,Policia,Copper Ch
 E90E0E,CX-MIE,Uruguay Police,Robinson R66,R66,Pol,Police Squad,Policia,Copper Chopper,Police Forces,https://w.wiki/B3LK
 E940FA,FAB-001,Gov of Bolivia,Dassault Falcon 900EX,F900,Gov,Government,Must Be Nice,Free And Fair Elections,Head of State,https://w.wiki/B3LJ
 E940FB,FAB-002,Gov of Bolivia,Dassault Falcon 50,FA50,Gov,Government,Must Be Nice,Free And Fair Elections,Head of State,https://w.wiki/B3LJ
+48D821,0214,Polish Air Force,PZL-Mielec M-28 Skytruck,M28,Mil,Skytruck,STOL,Flying Troops,Other Air Forces,https://w.wiki/4nEo
+48D824,0217,Polish Air Force,Antonov An-28,AN28,Mil,Skytruck,STOL,Flying Troops,Other Air Forces,https://w.wiki/4nEo
+48D825,0205,Polish Air Force,Antonov An-28,AN28,Mil,Skytruck,STOL,Flying Troops,Other Air Forces,https://w.wiki/4nEo
+48D828,0219,Polish Air Force,PZL-Mielec M-28 Skytruck,M28,Mil,Skytruck,STOL,Flying Troops,Other Air Forces,https://w.wiki/4nEo
+48D82C,0222,Polish Air Force,Antonov An-28,AN28,Mil,Skytruck,STOL,Flying Troops,Other Air Forces,https://w.wiki/4nEo
+48D82D,0223,Polish Air Force,PZL-Mielec M-28 Skytruck,M28,Mil,Skytruck,STOL,Flying Troops,Other Air Forces,https://w.wiki/4nEo
+48D82E,0224,Polish Air Force,PZL-Mielec M-28 Skytruck,M28,Mil,Skytruck,STOL,Flying Troops,Other Air Forces,https://w.wiki/4nEo
+48D840,011,Polish Air Force,CASA C-295 Persuader,C295,Mil,Cargo,Tactical Airlift,Flying Troops,Other Air Forces,https://w.wiki/4nEo
+48D842,013,Polish Air Force,CASA C-295 Persuader,C295,Mil,Cargo,Tactical Airlift,Flying Troops,Other Air Forces,https://w.wiki/4nEo
+48D844,015,Polish Air Force,CASA C-295 Persuader,C295,Mil,Cargo,Tactical Airlift,Flying Troops,Other Air Forces,https://w.wiki/4nEo
+48D845,016,Polish Air Force,CASA C-295 Persuader,C295,Mil,Cargo,Tactical Airlift,Flying Troops,Other Air Forces,https://w.wiki/4nEo
+48D847,018,Polish Air Force,CASA C-295 Persuader,C295,Mil,Cargo,Tactical Airlift,Flying Troops,Other Air Forces,https://w.wiki/4nEo
+48D849,020,Polish Air Force,CASA C-295 Persuader,C295,Mil,Cargo,Tactical Airlift,Flying Troops,Other Air Forces,https://w.wiki/4nEo
+48D84C,022,Polish Air Force,CASA C-295 Persuader,C295,Mil,Cargo,Tactical Airlift,Flying Troops,Other Air Forces,https://w.wiki/4nEo
+48D852,023,Polish Air Force,CASA C-295 Persuader,C295,Mil,Cargo,Tactical Airlift,Flying Troops,Other Air Forces,https://w.wiki/4nEo
+48D854,025,Polish Air Force,CASA C-295 Persuader,C295,Mil,Cargo,Tactical Airlift,Flying Troops,Other Air Forces,https://w.wiki/4nEo
+48D855,026,Polish Air Force,CASA C-295 Persuader,C295,Mil,Cargo,Tactical Airlift,Flying Troops,Other Air Forces,https://w.wiki/4nEo
+48D856,027,Polish Air Force,CASA C-295 Persuader,C295,Mil,Cargo,Tactical Airlift,Flying Troops,Other Air Forces,https://w.wiki/4nEo
+48D880,4040,Polish Air Force,General Dynamics F-16 Fighting Falcon,F16,Mil,Jet Fighter,Viper,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48D881,4041,Polish Air Force,General Dynamics F-16 Fighting Falcon,F16,Mil,Jet Fighter,Viper,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48D882,4042,Polish Air Force,General Dynamics F-16 Fighting Falcon,F16,Mil,Jet Fighter,Viper,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48D883,4043,Polish Air Force,General Dynamics F-16 Fighting Falcon,F16,Mil,Jet Fighter,Viper,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48D884,4044,Polish Air Force,General Dynamics F-16 Fighting Falcon,F16,Mil,Jet Fighter,Viper,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48D885,4045,Polish Air Force,General Dynamics F-16 Fighting Falcon,F16,Mil,Jet Fighter,Viper,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48D886,4046,Polish Air Force,General Dynamics F-16 Fighting Falcon,F16,Mil,Jet Fighter,Viper,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48D887,4047,Polish Air Force,General Dynamics F-16 Fighting Falcon,F16,Mil,Jet Fighter,Viper,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48D88B,4051,Polish Air Force,General Dynamics F-16 Fighting Falcon,F16,Mil,Jet Fighter,Viper,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48D88D,4053,Polish Air Force,General Dynamics F-16 Fighting Falcon,F16,Mil,Jet Fighter,Viper,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48D88E,4054,Polish Air Force,General Dynamics F-16 Fighting Falcon,F16,Mil,Jet Fighter,Viper,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48D88F,4055,Polish Air Force,General Dynamics F-16 Fighting Falcon,F16,Mil,Jet Fighter,Viper,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48D890,4056,Polish Air Force,General Dynamics F-16 Fighting Falcon,F16,Mil,Jet Fighter,Viper,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48D891,4057,Polish Air Force,General Dynamics F-16 Fighting Falcon,F16,Mil,Jet Fighter,Viper,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48D892,4058,Polish Air Force,General Dynamics F-16 Fighting Falcon,F16,Mil,Jet Fighter,Viper,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48D894,4060,Polish Air Force,General Dynamics F-16 Fighting Falcon,F16,Mil,Jet Fighter,Viper,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48D895,4061,Polish Air Force,General Dynamics F-16 Fighting Falcon,F16,Mil,Jet Fighter,Viper,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48D896,4062,Polish Air Force,General Dynamics F-16 Fighting Falcon,F16,Mil,Jet Fighter,Viper,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48D898,4064,Polish Air Force,General Dynamics F-16 Fighting Falcon,F16,Mil,Jet Fighter,Viper,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48D8A4,4076,Polish Air Force,General Dynamics F-16 Fighting Falcon,F16,Mil,Jet Fighter,Viper,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48D8A5,4077,Polish Air Force,General Dynamics F-16 Fighting Falcon,F16,Mil,Jet Fighter,Viper,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48D8A6,4078,Polish Air Force,General Dynamics F-16 Fighting Falcon,F16,Mil,Jet Fighter,Viper,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48D8A7,4079,Polish Air Force,General Dynamics F-16 Fighting Falcon,F16,Mil,Jet Fighter,Viper,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48D8A8,4080,Polish Air Force,General Dynamics F-16 Fighting Falcon,F16,Mil,Jet Fighter,Viper,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48D8A9,4081,Polish Air Force,General Dynamics F-16 Fighting Falcon,F16,Mil,Jet Fighter,Viper,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48D8AB,4083,Polish Air Force,General Dynamics F-16 Fighting Falcon,F16,Mil,Jet Fighter,Viper,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48D8AC,4084,Polish Air Force,General Dynamics F-16 Fighting Falcon,F16,Mil,Jet Fighter,Viper,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48D8AD,4085,Polish Air Force,General Dynamics F-16 Fighting Falcon,F16,Mil,Jet Fighter,Viper,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48D8AE,4086,Polish Air Force,General Dynamics F-16 Fighting Falcon,F16,Mil,Jet Fighter,Viper,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48D8AF,4087,Polish Air Force,General Dynamics F-16 Fighting Falcon,F16,Mil,Jet Fighter,Viper,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48D8E3,1504,Polish Air Force,Lockheed C-130 Hercules,C130,Mil,Chonky Boy,Tactical Airlift,Flying Troops,Other Air Forces,https://w.wiki/4nEo
+48D8EE,1511,Polish Air Force,Lockheed C-130 Hercules,C130,Mil,Chonky Boy,Tactical Airlift,Flying Troops,Other Air Forces,https://w.wiki/4nEo
+48D8F1,1512,Polish Air Force,Lockheed C-130 Hercules,C130,Mil,Chonky Boy,Tactical Airlift,Flying Troops,Other Air Forces,https://w.wiki/4nEo
+48D903,032,Polish Air Force,PZL-Okecie PZL-130 Orlik,PZ3T,Mil,Basic Trainer,Turboprop,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48D904,037,Polish Air Force,PZL-130 Orlik,PZ3T,Mil,Basic Trainer,Turboprop,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48D906,040,Polish Air Force,PZL-Okecie PZL-130 Orlik,PZ3T,Mil,Basic Trainer,Turboprop,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48D908,042,Polish Air Force,PZL-130 Orlik,PZ3T,Mil,Basic Trainer,Turboprop,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48D909,043,Polish Air Force,PZL-130 Orlik,PZ3T,Mil,Basic Trainer,Turboprop,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48D90B,047,Polish Air Force,PZL-130 Orlik,PZ3T,Mil,Basic Trainer,Turboprop,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48D90C,048,Polish Air Force,PZL-Okecie PZL-130 Orlik,PZ3T,Mil,Basic Trainer,Turboprop,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48D90E,050RED,Polish Air Force,PZL-Okecie PZL-130 Orlik,PZ3T,Mil,Basic Trainer,Turboprop,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48D910,052,Polish Air Force,PZL-130 Orlik,PZ3T,Mil,Basic Trainer,Turboprop,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48D911,019,Polish Air Force,PZL-130 Orlik,PZ3T,Mil,Basic Trainer,Turboprop,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48D913,022,Polish Air Force,PZL-130 Orlik,PZ3T,Mil,Basic Trainer,Turboprop,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48D914,023,Polish Air Force,PZL-130 Orlik,PZ3T,Mil,Basic Trainer,Turboprop,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48D915,024,Polish Air Force,PZL-130 Orlik,PZ3T,Mil,Basic Trainer,Turboprop,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48D916,025,Polish Air Force,PZL-130 Orlik,PZ3T,Mil,Basic Trainer,Turboprop,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48D920,036,Polish Air Force,PZL-Okecie PZL-130 Orlik,PZ3T,Mil,Basic Trainer,Turboprop,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48D922,045,Polish Air Force,PZL-130 Orlik,PZ3T,Mil,Basic Trainer,Turboprop,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48D923,049,Polish Air Force,PZL-130 Orlik,PZ3T,Mil,Basic Trainer,Turboprop,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48D9C5,83,Polish Air Force,Mikoyan MiG-29/33/35,MG29,Mil,Jet Fighter,Fulcrum,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48D9CD,89,Polish Air Force,Mikoyan MiG-29/33/35,MG29,Mil,Jet Fighter,Fulcrum,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48DA42,631,Polish Air Force,MIL Mi-8/9/17/19/171/172,MI8,Mil,Helicopter,Hip,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48DA43,633,Polish Air Force,MIL Mi-8/9/17/19/171/172,MI8,Mil,Helicopter,Hip,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48DA45,655,Polish Air Force,Mil Mi-8,MI8,Mil,Helicopter,Hip,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48DA46,630,Polish Air Force,Mil Mi-8,MI8,Mil,Helicopter,Hip,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48DA4C,605,Polish Air Force,MIL Mi-8/9/17/19/171/172,MI8,Mil,Helicopter,Hip,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48DA60,6201,Polish Air Force,Agusta Westland Eh-101 Merlin,EH10,Mil,Helicopter,Merlin,Marynarka Wojenna,Other Air Forces,https://w.wiki/4nEo
+48DA61,6202,Polish Air Force,Agusta Westland Eh-101 Merlin,EH10,Mil,Helicopter,Merlin,Marynarka Wojenna,Other Air Forces,https://w.wiki/4nEo
+48DA62,6203,Polish Air Force,Agusta Westland Eh-101 Merlin,EH10,Mil,Helicopter,Merlin,Marynarka Wojenna,Other Air Forces,https://w.wiki/4nEo
+48DA63,6204,Polish Air Force,Agusta Westland Eh-101 Merlin,EH10,Mil,Helicopter,Merlin,Marynarka Wojenna,Other Air Forces,https://w.wiki/4nEo
+48DA80,0915,Polish Air Force,PZL-Swidnik W-3,W3,Mil,Helicopter,Sokol,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48DA81,0916,Polish Air Force,PZL-Swidnik W-3,W3,Mil,Helicopter,Sokol,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48DA82,1014,Polish Air Force,PZL-Swidnik W-3,W3,Mil,Helicopter,Sokol,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48DA83,1015,Polish Air Force,PZL-Swidnik W-3,W3,Mil,Helicopter,Sokol,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48DA84,1016,Polish Air Force,PZL-Swidnik W-3,W3,Mil,Helicopter,Sokol,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48DA85,1017,Polish Air Force,PZL-Mielec M-28 Skytruck,M28,Mil,Skytruck,STOL,Flying Troops,Other Air Forces,https://w.wiki/4nEo
+48DA86,1018,Polish Air Force,PZL W-3 Sokol,W3,Mil,Helicopter,Sokol,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo
+48DA96,0419,Polish Air Force,PZL W-3 Sokol,W3,Mil,Helicopter,Sokol,Sily Powietrzne,Other Air Forces,https://w.wiki/4nEo


### PR DESCRIPTION
The database currently contains no Polish F-16s and only a partial
Polish military fleet (some Bryzas, C-295s, C-130s and the VIP flight).
This adds 87 aircraft: 30 F-16C/D, 2 MiG-29, 17 PZL-130 Orlik,
11 C-295M, 3 C-130, 8 Bryza/An-28, and 16 helicopters (W-3, Mi-8, AW101).

Hexes cross-referenced from tar1090-db and deduped against this list.
Styled to match the existing Polish entries (operator, link, tags).

Note: reg "024" now appears twice, that is correct, Polish serials
repeat across types (existing 024 = C-295 at 48D853, new 024 =
PZL-130 at 48D915).

I run an ADS-B feeder near Warsaw and have personally logged several
of these, including F-16 4077 (48D8A5).

Thanks for considering!