### PR TITLE
Add some missing miscellaneous planes

### DIFF
--- a/plane-alert-db.csv
+++ b/plane-alert-db.csv
@@ -16196,3 +16196,29 @@ E90E07,CX-MIA,Uruguay Police,Robinson R44,R44,Pol,Police Squad,Policia,Copper Ch
 E90E0E,CX-MIE,Uruguay Police,Robinson R66,R66,Pol,Police Squad,Policia,Copper Chopper,Police Forces,https://w.wiki/B3LK
 E940FA,FAB-001,Gov of Bolivia,Dassault Falcon 900EX,F900,Gov,Government,Must Be Nice,Free And Fair Elections,Head of State,https://w.wiki/B3LJ
 E940FB,FAB-002,Gov of Bolivia,Dassault Falcon 50,FA50,Gov,Government,Must Be Nice,Free And Fair Elections,Head of State,https://w.wiki/B3LJ
+1F6FA9,RF-94121,Russian Navy,Tupolev Tu-142,TU95,Mil,Cold Warrior,Bear,Da Comrade,Other Air Forces,https://en.wikipedia.org/wiki/Tupolev_Tu-142
+483123,SN-50YG,Polish Border Guard,Piper PA-34 Seneca,PA34,Gov,Border Patrol,Straz Graniczna,Surveillance,Coastguard,https://www.strazgraniczna.pl
+488FE8,SP-MXH,Polish Medical Air Service,Piaggio P-180 Avanti EVO,P180,Civ,Air Ambo,Medical Evac,Saving Lives,Flying Doctors,https://www.lpr.com.pl/en/home-page/
+489ECF,SP-HXP,Polish Medical Air Service,Eurocopter EC135 P2+,EC35,Civ,Air Ambo,Medical Evac,Saving Lives,Flying Doctors,https://www.lpr.com.pl/en/home-page/
+489ED6,SP-HXX,Polish Medical Air Service,Eurocopter EC135 P2+,EC35,Civ,Air Ambo,Medical Evac,Saving Lives,Flying Doctors,https://www.lpr.com.pl/en/home-page/
+48B0DE,SN-61YG,Polish Border Guard,LET L-410 UVP-E20 Turbolet,L410,Gov,Border Patrol,Straz Graniczna,Surveillance,Coastguard,https://www.strazgraniczna.pl
+48B15E,SN-62YG,Polish Border Guard,LET L-410 UVP-E20 Turbolet,L410,Gov,Border Patrol,Straz Graniczna,Surveillance,Coastguard,https://www.strazgraniczna.pl
+48B2C8,SP-MXI,Polish Medical Air Service,Piaggio P-180 Avanti EVO,P180,Civ,Air Ambo,Medical Evac,Saving Lives,Flying Doctors,https://www.lpr.com.pl/en/home-page/
+48B2CA,SP-MXI,Polish Medical Air Service,Piaggio P-180 Avanti EVO,P180,Civ,Air Ambo,Medical Evac,Saving Lives,Flying Doctors,https://www.lpr.com.pl/en/home-page/
+48C0DE,SN-45YG,Polish Border Guard,PZL-104M Wilga 2000,PZ4M,Gov,Border Patrol,Straz Graniczna,Surveillance,Coastguard,https://www.strazgraniczna.pl
+48C15E,SN-42YG,Polish Border Guard,PZL-104M Wilga 2000,PZ4M,Gov,Border Patrol,Straz Graniczna,Surveillance,Coastguard,https://www.strazgraniczna.pl
+48C4DE,SN-48YG,Polish Border Guard,Safran S-15 Patroller UAV,S15U,Gov,UAV,Straz Graniczna,Surveillance,Coastguard,https://www.strazgraniczna.pl
+48C65E,SN-47YG,Polish Border Guard,Stemme S-15,S15S,Gov,Border Patrol,Straz Graniczna,Surveillance,Coastguard,https://www.strazgraniczna.pl
+48F3A5,SN-73XP,Polish Police,Sikorsky S-70i Black Hawk,H60,Pol,Police Squad,Policja,Copper Chopper,Police Forces,https://policja.pl
+48F3A6,SN-74XP,Polish Police,Sikorsky S-70i Black Hawk,H60,Pol,Police Squad,Policja,Copper Chopper,Police Forces,https://policja.pl
+48F3A7,SN-80XP,Polish Police,Bell 407GXi,B407,Pol,Police Squad,Policja,Copper Chopper,Police Forces,https://policja.pl
+48F3A8,SN-81XP,Polish Police,Bell 407GXi,B407,Pol,Police Squad,Policja,Copper Chopper,Police Forces,https://policja.pl
+48F3A9,SN-82XP,Polish Police,Bell 407GXi,B407,Pol,Police Squad,Policja,Copper Chopper,Police Forces,https://policja.pl
+48F3AB,SN-83XP,Polish Police,Bell 407GXi,B407,Pol,Police Squad,Policja,Copper Chopper,Police Forces,https://policja.pl
+48F3AC,SN-84XP,Polish Police,Bell 407GXi,B407,Pol,Police Squad,Policja,Copper Chopper,Police Forces,https://policja.pl
+48F3AD,SN-85XP,Polish Police,Bell 407GXi,B407,Pol,Police Squad,Policja,Copper Chopper,Police Forces,https://policja.pl
+48F3AE,SN-86XP,Polish Police,Bell 407GXi,B407,Pol,Police Squad,Policja,Copper Chopper,Police Forces,https://policja.pl
+4D03CD,LX-N90455,NATO,Boeing E-3A Sentry,E3TF,Mil,Battle Management,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Boeing_E-3_Sentry
+AE6BD4,85-0068,USAF,Rockwell B-1B Lancer,B1,Mil,Cold Warrior,Strategic Bomber,Bone,USAF,https://en.wikipedia.org/wiki/Rockwell_B-1_Lancer
+AE6BDA,85-0079,USAF,Rockwell B-1B Lancer,B1,Mil,Cold Warrior,Strategic Bomber,Bone,USAF,https://en.wikipedia.org/wiki/Rockwell_B-1_Lancer
+AE6BDE,85-0084,USAF,Rockwell B-1 Lancer,B1,Mil,Cold Warrior,Strategic Bomber,Bone,USAF,https://en.wikipedia.org/wiki/Rockwell_B-1_Lancer


### PR DESCRIPTION
Continuing the series (see #825). 

Mixed batch of special aircraft that regularly fly over Poland, plus a few strategic stragglers: 
Polish Medical Air Service Piaggio P.180s and two missing EC135s, Polish Police S-70i/Bell 407 helicopters, the Polish Border Guard fleet (including their Safran Patroller UAV), three B-1Bs, a missing NATO E-3A, and a Russian Navy Tu-142. 

Styled to match existing entries for each operator. 

Thanks!