### PR TITLE
Add 16 E-6 Mercurys under their new hexes

### DIFF
--- a/plane-alert-db.csv
+++ b/plane-alert-db.csv
@@ -16222,3 +16222,19 @@ E90E07,CX-MIA,Uruguay Police,Robinson R44,R44,Pol,Police Squad,Policia,Copper Ch
 E90E0E,CX-MIE,Uruguay Police,Robinson R66,R66,Pol,Police Squad,Policia,Copper Chopper,Police Forces,https://w.wiki/B3LK
 E940FA,FAB-001,Gov of Bolivia,Dassault Falcon 900EX,F900,Gov,Government,Must Be Nice,Free And Fair Elections,Head of State,https://w.wiki/B3LJ
 E940FB,FAB-002,Gov of Bolivia,Dassault Falcon 50,FA50,Gov,Government,Must Be Nice,Free And Fair Elections,Head of State,https://w.wiki/B3LJ
+AE2925,162782,United States Navy,Boeing E-6B Mercury,E6,Mil,Quarterback,Looking Glass,TACAMO,Distinctive,https://en.wikipedia.org/wiki/Boeing_E-6_Mercury
+AE2926,162783,United States Navy,Boeing E-6B Mercury,E6,Mil,Quarterback,Looking Glass,TACAMO,Distinctive,https://en.wikipedia.org/wiki/Boeing_E-6_Mercury
+AE2927,162784,United States Navy,Boeing E-6B Mercury,E6,Mil,Quarterback,Looking Glass,TACAMO,Distinctive,https://en.wikipedia.org/wiki/Boeing_E-6_Mercury
+AE2928,163918,United States Navy,Boeing E-6B Mercury,E6,Mil,Quarterback,Looking Glass,TACAMO,Distinctive,https://en.wikipedia.org/wiki/Boeing_E-6_Mercury
+AE2929,163919,United States Navy,Boeing E-6B Mercury,E6,Mil,Quarterback,Looking Glass,TACAMO,Distinctive,https://en.wikipedia.org/wiki/Boeing_E-6_Mercury
+AE292A,163920,United States Navy,Boeing E-6B Mercury,E6,Mil,Quarterback,Looking Glass,TACAMO,Distinctive,https://en.wikipedia.org/wiki/Boeing_E-6_Mercury
+AE292B,164386,United States Navy,Boeing E-6B Mercury,E6,Mil,Quarterback,Looking Glass,TACAMO,Distinctive,https://en.wikipedia.org/wiki/Boeing_E-6_Mercury
+AE292C,164387,United States Navy,Boeing E-6B Mercury,E6,Mil,Quarterback,Looking Glass,TACAMO,Distinctive,https://en.wikipedia.org/wiki/Boeing_E-6_Mercury
+AE292D,164388,United States Navy,Boeing E-6B Mercury,E6,Mil,Quarterback,Looking Glass,TACAMO,Distinctive,https://en.wikipedia.org/wiki/Boeing_E-6_Mercury
+AE292E,164404,United States Navy,Boeing E-6B Mercury,E6,Mil,Quarterback,Looking Glass,TACAMO,Distinctive,https://en.wikipedia.org/wiki/Boeing_E-6_Mercury
+AE292F,164405,United States Navy,Boeing E-6B Mercury,E6,Mil,Quarterback,Looking Glass,TACAMO,Distinctive,https://en.wikipedia.org/wiki/Boeing_E-6_Mercury
+AE2930,164406,United States Navy,Boeing E-6B Mercury,E6,Mil,Quarterback,Looking Glass,TACAMO,Distinctive,https://en.wikipedia.org/wiki/Boeing_E-6_Mercury
+AE2931,164407,United States Navy,Boeing E-6B Mercury,E6,Mil,Quarterback,Looking Glass,TACAMO,Distinctive,https://en.wikipedia.org/wiki/Boeing_E-6_Mercury
+AE2932,164408,United States Navy,Boeing E-6B Mercury,E6,Mil,Quarterback,Looking Glass,TACAMO,Distinctive,https://en.wikipedia.org/wiki/Boeing_E-6_Mercury
+AE2933,164409,United States Navy,Boeing E-6B Mercury,E6,Mil,Quarterback,Looking Glass,TACAMO,Distinctive,https://en.wikipedia.org/wiki/Boeing_E-6_Mercury
+AE2934,164410,United States Navy,Boeing E-6B Mercury,E6,Mil,Quarterback,Looking Glass,TACAMO,Distinctive,https://en.wikipedia.org/wiki/Boeing_E-6_Mercury


### PR DESCRIPTION
Continuing the series (see #825). 

This adds the E-6B Mercury fleet under their newer AE29xx hexes, same situation as the Turkish E-7Ts in #827: 
the fleet was re-hexed (from AE04xx), and these are the hexes they broadcast now (alteast according to tar1090-db). Old rows left in place per that discussion. Hexes from tar1090-db, deduped against the current list, styled like the existing E-6B entries. 

Thanks!