### PR TITLE
add 78 E-2 Hawkeyes

### DIFF
--- a/plane-alert-db.csv
+++ b/plane-alert-db.csv
@@ -16238,3 +16238,81 @@ E90E07,CX-MIA,Uruguay Police,Robinson R44,R44,Pol,Police Squad,Policia,Copper Ch
 E90E0E,CX-MIE,Uruguay Police,Robinson R66,R66,Pol,Police Squad,Policia,Copper Chopper,Police Forces,https://w.wiki/B3LK
 E940FA,FAB-001,Gov of Bolivia,Dassault Falcon 900EX,F900,Gov,Government,Must Be Nice,Free And Fair Elections,Head of State,https://w.wiki/B3LJ
 E940FB,FAB-002,Gov of Bolivia,Dassault Falcon 50,FA50,Gov,Government,Must Be Nice,Free And Fair Elections,Head of State,https://w.wiki/B3LJ
+AE1B08,168276,United States Navy,Grumman E-2C Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE1DF0,163849,United States Navy,Grumman E-2C Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE24E2,165647,United States Navy,Grumman E-2D Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE24E3,165648,United States Navy,Grumman E-2D Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE24E4,165649,United States Navy,Grumman E-2D Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE24E6,165811,United States Navy,Grumman E-2C Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE24E7,165812,United States Navy,Grumman E-2C Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE24E8,165813,United States Navy,Grumman E-2C Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE24E9,165814,United States Navy,Grumman E-2C Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE24EA,165815,United States Navy,Grumman E-2C Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE24EB,165816,United States Navy,Grumman E-2C Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE24EF,165820,United States Navy,Grumman E-2C Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE24F0,165821,United States Navy,Grumman E-2C Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE24F2,165823,United States Navy,Grumman E-2C Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE24F3,165824,United States Navy,Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE24F4,165825,United States Navy,Grumman E-2C Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE24F5,165826,United States Navy,Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE24F6,165827,United States Navy,Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE24F7,165828,United States Navy,Grumman E-2C Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE24F9,166508,United States Navy,Grumman E-2C Hawkeye 2000,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE24FA,166505,United States Navy,Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE24FB,166506,United States Navy,Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE24FC,166506,United States Navy,Grumman E-2C Hawkeye 2000,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE24FD,166508,United States Navy,Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE2FD1,166501,United States Navy,Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE2FD3,167929,United States Navy,Grumman E-2D Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE2FD4,167930,United States Navy,Northrop Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE2FD5,167931,United States Navy,Northrop Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE2FD7,168077,United States Navy,Grumman E-2D Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE4D99,168276,United States Navy,Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE5385,168321,United States Navy,Northrop Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE5386,168592,United States Navy,Northrop Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE5387,168593,United States Navy,Northrop Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE5388,168594,United States Navy,Northrop Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE5389,168595,United States Navy,Northrop Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE538B,168597,United States Navy,Northrop Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE538C,168598,United States Navy,Northrop Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE5BA2,168989,United States Navy,Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE5BA3,168990,United States Navy,Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE5BA4,168991,United States Navy,Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE5BA5,168992,United States Navy,Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE5BA6,168993,United States Navy,Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE5BA8,169061,United States Navy,Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE5BA9,169062,United States Navy,Grumman E-2D Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE5BAA,169063,United States Navy,Grumman E-2D Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE5E49,169067,United States Navy,Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE5E4A,169068,United States Navy,Northrop Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE5E4B,169069,United States Navy,Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE5E4C,169070,United States Navy,Northrop Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE5E4D,169071,United States Navy,Northrop Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE5E4E,169072,United States Navy,Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE5E4F,169073,United States Navy,Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE5E50,169074,United States Navy,Northrop Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE5E51,169075,United States Navy,Northrop Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE5E52,169076,United States Navy,Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE5E54,169078,United States Navy,Northrop Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE5E56,169080,United States Navy,Northrop Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE5E57,169081,United States Navy,Northrop Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE5E58,169082,United States Navy,Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE5E59,169083,United States Navy,Northrop Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE5E5A,169084,United States Navy,Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE5E5B,169085,United States Navy,Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE7447,169863,United States Navy,Northrop Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE7448,169864,United States Navy,Northrop Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE7449,169865,United States Navy,Grumman E-2D Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE744A,169866,United States Navy,Grumman E-2D Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE744B,169867,United States Navy,Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE744C,169868,United States Navy,Grumman E-2D Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE744D,169869,United States Navy,Northrop Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE744E,169870,United States Navy,Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE744F,169871,United States Navy,Northrop Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE7450,169872,United States Navy,Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE7451,169873,United States Navy,Northrop Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE7452,169874,United States Navy,Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE7453,169875,United States Navy,Northrop Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE7454,169876,United States Navy,Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE7455,169877,United States Navy,Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye
+AE7456,169878,United States Navy,Grumman E-2 Hawkeye,E2,Mil,Hawkeye,AEW,Eye In The Sky,Oxcart,https://en.wikipedia.org/wiki/Northrop_Grumman_E-2_Hawkeye


### PR DESCRIPTION
Continuing the series (see #825). 

This adds 78 E-2 Hawkeyes, all US Navy E-2C/D airframes (the French ones are already in the list). 
Hexes from tar1090-db, deduped against the current list, styled like the existing Hawkeye entries. 

Note: the USN retired its last E-2Cs fairly recently, so a few airframes may be stale, happy to trim.

Thanks!