### PR TITLE
add 51 strategic and tactical transports

### DIFF
--- a/plane-alert-db.csv
+++ b/plane-alert-db.csv
@@ -16417,3 +16417,54 @@ E90E07,CX-MIA,Uruguay Police,Robinson R44,R44,Pol,Police Squad,Policia,Copper Ch
 E90E0E,CX-MIE,Uruguay Police,Robinson R66,R66,Pol,Police Squad,Policia,Copper Chopper,Police Forces,https://w.wiki/B3LK
 E940FA,FAB-001,Gov of Bolivia,Dassault Falcon 900EX,F900,Gov,Government,Must Be Nice,Free And Fair Elections,Head of State,https://w.wiki/B3LJ
 E940FB,FAB-002,Gov of Bolivia,Dassault Falcon 50,FA50,Gov,Government,Must Be Nice,Free And Fair Elections,Head of State,https://w.wiki/B3LJ
+06A249,A7-MAB,Qatar Emiri Air Force,Boeing C-17 Globemaster III,C17,Mil,Tactical Airlift,Globemaster,Cargo,Other Air Forces,https://en.wikipedia.org/wiki/Boeing_C-17_Globemaster_III
+15405C,RA-82012,Russian Air Force,Antonov An-124 Ruslan,A124,Mil,Absolute Unit,Vashe Zdorovye,Condor,Other Air Forces,https://en.wikipedia.org/wiki/Antonov_An-124_Ruslan
+343603,EC-400,Airbus Defence and Space,Airbus A-400M,A400,Mil,Tactical Airlift,Military Transport,Cargo,Other Air Forces,https://en.wikipedia.org/wiki/Airbus_A400M_Atlas
+3532C1,T.23-01,Spanish Air Force,Airbus A-400M,A400,Mil,Tactical Airlift,Military Transport,Cargo,Other Air Forces,https://en.wikipedia.org/wiki/Airbus_A400M_Atlas
+3532C2,T.23-04,Spanish Air Force,Airbus A-400M,A400,Mil,Tactical Airlift,Military Transport,Cargo,Other Air Forces,https://en.wikipedia.org/wiki/Airbus_A400M_Atlas
+3532C6,TK.23-02,Spanish Air Force,Airbus A-400M,A400,Mil,Tactical Airlift,Military Transport,Cargo,Other Air Forces,https://en.wikipedia.org/wiki/Airbus_A400M_Atlas
+3532C8,TK.23-09,Spanish Air Force,Airbus A-400M,A400,Mil,Tactical Airlift,Military Transport,Cargo,Other Air Forces,https://en.wikipedia.org/wiki/Airbus_A400M_Atlas
+3532CC,T.23-12,Spanish Air Force,Airbus A-400M,A400,Mil,Tactical Airlift,Military Transport,Cargo,Other Air Forces,https://en.wikipedia.org/wiki/Airbus_A400M_Atlas
+3532CD,T.23-13,Spanish Air Force,Airbus A-400M,A400,Mil,Tactical Airlift,Military Transport,Cargo,Other Air Forces,https://en.wikipedia.org/wiki/Airbus_A400M_Atlas
+3532CE,TK.23-14,Spanish Air Force,Airbus A-400M,A400,Mil,Tactical Airlift,Military Transport,Cargo,Other Air Forces,https://en.wikipedia.org/wiki/Airbus_A400M_Atlas
+3B775A,F-RBAY,French Air and Space Force,Airbus A-400M,A400,Mil,Tactical Airlift,Military Transport,Cargo,Other Air Forces,https://en.wikipedia.org/wiki/Airbus_A400M_Atlas
+3E8B02,54+40,German Air Force,Airbus A-400M,A400,Mil,Tactical Airlift,Military Transport,Cargo,Other Air Forces,https://en.wikipedia.org/wiki/Airbus_A400M_Atlas
+3E91EE,54+41,German Air Force,Airbus A-400M,A400,Mil,Tactical Airlift,Military Transport,Cargo,Other Air Forces,https://en.wikipedia.org/wiki/Airbus_A400M_Atlas
+3E9808,54+46,German Air Force,Airbus A-400M,A400,Mil,Tactical Airlift,Military Transport,Cargo,Other Air Forces,https://en.wikipedia.org/wiki/Airbus_A400M_Atlas
+3EA541,54+19,German Air Force,Airbus A-400M,A400,Mil,Tactical Airlift,Military Transport,Cargo,Other Air Forces,https://en.wikipedia.org/wiki/Airbus_A400M_Atlas
+3EA556,54+10,German Air Force,Airbus A-400M,A400,Mil,Tactical Airlift,Military Transport,Cargo,Other Air Forces,https://en.wikipedia.org/wiki/Airbus_A400M_Atlas
+3EA5BC,54+45,German Air Force,Airbus A-400M,A400,Mil,Tactical Airlift,Military Transport,Cargo,Other Air Forces,https://en.wikipedia.org/wiki/Airbus_A400M_Atlas
+3F43D4,54+03,German Air Force,Airbus A-400M,A400,Mil,Tactical Airlift,Military Transport,Cargo,Other Air Forces,https://en.wikipedia.org/wiki/Airbus_A400M_Atlas
+3F43E6,54+47,German Air Force,Airbus A-400M,A400,Mil,Tactical Airlift,Military Transport,Cargo,Other Air Forces,https://en.wikipedia.org/wiki/Airbus_A400M_Atlas
+3F447A,54+43,German Air Force,Airbus A-400M,A400,Mil,Tactical Airlift,Military Transport,Cargo,Other Air Forces,https://en.wikipedia.org/wiki/Airbus_A400M_Atlas
+3F4E62,54+62,German Air Force,Airbus A-400M,A400,Mil,Tactical Airlift,Military Transport,Cargo,Other Air Forces,https://en.wikipedia.org/wiki/Airbus_A400M_Atlas
+3F5342,54+35,German Air Force,Airbus A-400M,A400,Mil,Tactical Airlift,Military Transport,Cargo,Other Air Forces,https://en.wikipedia.org/wiki/Airbus_A400M_Atlas
+3F54B3,54+63,German Air Force,Airbus A-400M,A400,Mil,Tactical Airlift,Military Transport,Cargo,Other Air Forces,https://en.wikipedia.org/wiki/Airbus_A400M_Atlas
+3F5685,54+30,German Air Force,Airbus A-400M,A400,Mil,Tactical Airlift,Military Transport,Cargo,Other Air Forces,https://en.wikipedia.org/wiki/Airbus_A400M_Atlas
+3F56E6,54+42,German Air Force,Airbus A-400M,A400,Mil,Tactical Airlift,Military Transport,Cargo,Other Air Forces,https://en.wikipedia.org/wiki/Airbus_A400M_Atlas
+3F5BFF,54+61,German Air Force,Airbus A-400M,A400,Mil,Tactical Airlift,Military Transport,Cargo,Other Air Forces,https://en.wikipedia.org/wiki/Airbus_A400M_Atlas
+3F7E3D,54+50,German Air Force,Airbus A-400M,A400,Mil,Tactical Airlift,Military Transport,Cargo,Other Air Forces,https://en.wikipedia.org/wiki/Airbus_A400M_Atlas
+44F687,CT-07,Belgian Air Component,Airbus A-400M,A400,Mil,Tactical Airlift,Military Transport,Cargo,Other Air Forces,https://en.wikipedia.org/wiki/Airbus_A400M_Atlas
+44F688,CT-08,Belgian Air Component,Airbus A-400M,A400,Mil,Tactical Airlift,Military Transport,Cargo,Other Air Forces,https://en.wikipedia.org/wiki/Airbus_A400M_Atlas
+4B820B,13-0009,Turkish Air Force,Airbus A-400M,A400,Mil,Tactical Airlift,Military Transport,Cargo,Other Air Forces,https://en.wikipedia.org/wiki/Airbus_A400M_Atlas
+4B820C,14-0013,Turkish Air Force,Airbus A-400M,A400,Mil,Tactical Airlift,Military Transport,Cargo,Other Air Forces,https://en.wikipedia.org/wiki/Airbus_A400M_Atlas
+4B820D,21-0118,Turkish Air Force,Airbus A-400M,A400,Mil,Tactical Airlift,Military Transport,Cargo,Other Air Forces,https://en.wikipedia.org/wiki/Airbus_A400M_Atlas
+4B820E,14-0028,Turkish Air Force,Airbus A-400M,A400,Mil,Tactical Airlift,Military Transport,Cargo,Other Air Forces,https://en.wikipedia.org/wiki/Airbus_A400M_Atlas
+4B8210,16-0055,Turkish Air Force,Airbus A-400M,A400,Mil,Tactical Airlift,Military Transport,Cargo,Other Air Forces,https://en.wikipedia.org/wiki/Airbus_A400M_Atlas
+4B8211,17-0078,Turkish Air Force,Airbus A-400M,A400,Mil,Tactical Airlift,Military Transport,Cargo,Other Air Forces,https://en.wikipedia.org/wiki/Airbus_A400M_Atlas
+4B8212,17-0080,Turkish Air Force,Airbus A-400M,A400,Mil,Tactical Airlift,Military Transport,Cargo,Other Air Forces,https://en.wikipedia.org/wiki/Airbus_A400M_Atlas
+4B8213,18-0093,Turkish Air Force,Airbus A-400M,A400,Mil,Tactical Airlift,Military Transport,Cargo,Other Air Forces,https://en.wikipedia.org/wiki/Airbus_A400M_Atlas
+4B8214,18-0094,Turkish Air Force,Airbus A-400M,A400,Mil,Tactical Airlift,Military Transport,Cargo,Other Air Forces,https://en.wikipedia.org/wiki/Airbus_A400M_Atlas
+68324F,21,Kazakhstan Air Defense Forces,Airbus A400M Atlas,A400,Mil,Tactical Airlift,Military Transport,Cargo,Other Air Forces,https://en.wikipedia.org/wiki/Airbus_A400M_Atlas
+750327,M54-01,Royal Malaysian Air Force,Airbus A-400M,A400,Mil,Tactical Airlift,Military Transport,Cargo,Other Air Forces,https://en.wikipedia.org/wiki/Airbus_A400M_Atlas
+750328,M54-02,Royal Malaysian Air Force,Airbus A-400M,A400,Mil,Tactical Airlift,Military Transport,Cargo,Other Air Forces,https://en.wikipedia.org/wiki/Airbus_A400M_Atlas
+750329,M54-03,Royal Malaysian Air Force,Airbus A-400M,A400,Mil,Tactical Airlift,Military Transport,Cargo,Other Air Forces,https://en.wikipedia.org/wiki/Airbus_A400M_Atlas
+75032A,M54-04,Royal Malaysian Air Force,Airbus A-400M,A400,Mil,Tactical Airlift,Military Transport,Cargo,Other Air Forces,https://en.wikipedia.org/wiki/Airbus_A400M_Atlas
+800790,CB-8003,Indian Air Force,Boeing C-17 Globemaster III,C17,Mil,Tactical Airlift,Globemaster,Cargo,Other Air Forces,https://en.wikipedia.org/wiki/Boeing_C-17_Globemaster_III
+800792,CB-8005,Indian Air Force,Boeing C-17 Globemaster III,C17,Mil,Tactical Airlift,Globemaster,Cargo,Other Air Forces,https://en.wikipedia.org/wiki/Boeing_C-17_Globemaster_III
+800E63,CB-8011,Indian Air Force,Boeing C-17 Globemaster III,C17,Mil,Tactical Airlift,Globemaster,Cargo,Other Air Forces,https://en.wikipedia.org/wiki/Boeing_C-17_Globemaster_III
+896C2B,1223,United Arab Emirates Air Force,Boeing C-17 Globemaster III,C17,Mil,Tactical Airlift,Globemaster,Cargo,Other Air Forces,https://en.wikipedia.org/wiki/Boeing_C-17_Globemaster_III
+8A0A25,A-4001,Indonesian Air Force,Airbus A-400M,A400,Mil,Tactical Airlift,Military Transport,Cargo,Other Air Forces,https://en.wikipedia.org/wiki/Airbus_A400M_Atlas
+8A0A26,A-4002,Indonesian Air Force,Airbus A-400M,A400,Mil,Tactical Airlift,Military Transport,Cargo,Other Air Forces,https://en.wikipedia.org/wiki/Airbus_A400M_Atlas
+AE052C,69-0006,USAF,Lockheed C-5M Super Galaxy,C5M,Mil,Absolute Unit,Strategic Airlift,Cargo,USAF,https://en.wikipedia.org/wiki/Lockheed_C-5_Galaxy
+AE08C3,98-0057,USAF,Boeing C-17A Globemaster III,C17,Mil,Tactical Airlift,Globemaster,Cargo,USAF,https://en.wikipedia.org/wiki/Boeing_C-17_Globemaster_III


### PR DESCRIPTION
Continuing the series.

This adds 51 strategic and tactical transports: 
C-17s (incl. Qatari and UAE airframes), 43 A400M Atlases across the operators (incl. the Malaysian, Indonesian, and Kazakh fleets), one C-5M, and one An-124. 

Hexes from tar1090-db, deduped against the current list, styled to match existing entries for each type. 

Thanks!