### PR TITLE
Add 37 algerian air force planes

### DIFF
--- a/plane-alert-db.csv
+++ b/plane-alert-db.csv
@@ -16549,3 +16549,40 @@ E90E07,CX-MIA,Uruguay Police,Robinson R44,R44,Pol,Police Squad,Policia,Copper Ch
 E90E0E,CX-MIE,Uruguay Police,Robinson R66,R66,Pol,Police Squad,Policia,Copper Chopper,Police Forces,https://w.wiki/B3LK
 E940FA,FAB-001,Gov of Bolivia,Dassault Falcon 900EX,F900,Gov,Government,Must Be Nice,Free And Fair Elections,Head of State,https://w.wiki/B3LJ
 E940FB,FAB-002,Gov of Bolivia,Dassault Falcon 50,FA50,Gov,Government,Must Be Nice,Free And Fair Elections,Head of State,https://w.wiki/B3LJ
+0A4010,7T-WHS,Algerian Air Force,Lockheed C-130H Hercules,C130,Mil,Cargo,Tactical Airlift,Matsharfeen,Other Air Forces,https://w.wiki/Dstq
+0A4011,7T-WHY,Algerian Air Force,Lockheed C-130H Hercules,C130,Mil,Cargo,Tactical Airlift,Matsharfeen,Other Air Forces,https://w.wiki/Dstq
+0A4012,7T-WHZ,Algerian Air Force,Lockheed C-130H Hercules,C130,Mil,Cargo,Tactical Airlift,Matsharfeen,Other Air Forces,https://w.wiki/Dstq
+0A4015,7T-WHR,Algerian Air Force,Lockheed C-130H Hercules,C130,Mil,Cargo,Tactical Airlift,Matsharfeen,Other Air Forces,https://w.wiki/Dstq
+0A4017,7T-WHJ,Algerian Air Force,Lockheed C-130H Hercules,C130,Mil,Cargo,Tactical Airlift,Matsharfeen,Other Air Forces,https://w.wiki/Dstq
+0A4018,7T-WHI,Algerian Air Force,Lockheed C-130H Hercules,C130,Mil,Cargo,Tactical Airlift,Matsharfeen,Other Air Forces,https://w.wiki/Dstq
+0A4019,7T-WHF,Algerian Air Force,Lockheed C-130H Hercules,C130,Mil,Cargo,Tactical Airlift,Matsharfeen,Other Air Forces,https://w.wiki/Dstq
+0A401A,7T-WHE,Algerian Air Force,Lockheed C-130H Hercules,C130,Mil,Cargo,Tactical Airlift,Matsharfeen,Other Air Forces,https://w.wiki/Dstq
+0A401C,7T-WHL,Algerian Air Force,Lockheed C-130H Hercules,C130,Mil,Cargo,Tactical Airlift,Matsharfeen,Other Air Forces,https://w.wiki/Dstq
+0A401E,7T-WHB,Algerian Air Force,Lockheed C-130H Hercules,C130,Mil,Cargo,Tactical Airlift,Matsharfeen,Other Air Forces,https://w.wiki/Dstq
+0A401F,7T-WIA,Algerian Air Force,Ilyushin Il-76TD,IL76,Mil,Cargo,Strategic Airlift,Candid,Other Air Forces,https://w.wiki/Dstq
+0A4020,7T-WIB,Algerian Air Force,Ilyushin Il-76TD,IL76,Mil,Cargo,Strategic Airlift,Candid,Other Air Forces,https://w.wiki/Dstq
+0A4021,7T-WIC,Algerian Air Force,Ilyushin Il-76TD,IL76,Mil,Cargo,Strategic Airlift,Candid,Other Air Forces,https://w.wiki/Dstq
+0A4023,7T-WIE,Algerian Air Force,Ilyushin Il-76TD,IL76,Mil,Cargo,Strategic Airlift,Candid,Other Air Forces,https://w.wiki/Dstq
+0A4025,7T-WIP,Algerian Air Force,Ilyushin Il-76TD,IL76,Mil,Cargo,Strategic Airlift,Candid,Other Air Forces,https://w.wiki/Dstq
+0A4028,7T-WIM,Algerian Air Force,Ilyushin Il-76TD,IL76,Mil,Cargo,Strategic Airlift,Candid,Other Air Forces,https://w.wiki/Dstq
+0A402A,7T-WIT,Algerian Air Force,Ilyushin Il-76TD,IL76,Mil,Cargo,Strategic Airlift,Candid,Other Air Forces,https://w.wiki/Dstq
+0A4039,7T-WRJ,Algerian Air Force,Beechcraft King Air 350,B350,Mil,Surveillance,Liaison,Eye In The Sky,Other Air Forces,https://w.wiki/Dstq
+0A403A,7T-WRL,Algerian Air Force,Beechcraft King Air 350,B350,Mil,Surveillance,Liaison,Eye In The Sky,Other Air Forces,https://w.wiki/Dstq
+0A403B,7T-WRM,Algerian Air Force,Beechcraft King Air 350,B350,Mil,Surveillance,Liaison,Eye In The Sky,Other Air Forces,https://w.wiki/Dstq
+0A403C,7T-WRN,Algerian Air Force,Beechcraft King Air 350,B350,Mil,Surveillance,Liaison,Eye In The Sky,Other Air Forces,https://w.wiki/Dstq
+0A403D,7T-WRP,Algerian Air Force,Beechcraft King Air 350,B350,Mil,Surveillance,Liaison,Eye In The Sky,Other Air Forces,https://w.wiki/Dstq
+0A403E,7T-WRQ,Algerian Air Force,Beechcraft King Air 350,B350,Mil,Surveillance,Liaison,Eye In The Sky,Other Air Forces,https://w.wiki/Dstq
+0A4044,7T-WVB,Algerian Air Force,AgustaWestland AW101 Merlin,EH10,Mil,Helicopter,Rotorhead,Merlin,Other Air Forces,https://w.wiki/Dstq
+0A4045,7T-WVD,Algerian Air Force,AgustaWestland AW101 Merlin,EH10,Mil,Helicopter,Rotorhead,Merlin,Other Air Forces,https://w.wiki/Dstq
+0A404F,7T-WRG,Algerian Air Force,Beechcraft Super King Air 200,BE20,Mil,Surveillance,Liaison,Eye In The Sky,Other Air Forces,https://w.wiki/Dstq
+0A4053,7T-WRA,Algerian Air Force,Beechcraft 1900D,B190,Mil,Surveillance,Liaison,Eye In The Sky,Other Air Forces,https://w.wiki/Dstq
+0A4054,7T-WRB,Algerian Air Force,Beechcraft 1900D,B190,Mil,Surveillance,Liaison,Eye In The Sky,Other Air Forces,https://w.wiki/Dstq
+0A4055,7T-WRC,Algerian Air Force,Beechcraft 1900D,B190,Mil,Surveillance,Liaison,Eye In The Sky,Other Air Forces,https://w.wiki/Dstq
+0A4056,7T-WRD,Algerian Air Force,Beechcraft 1900D,B190,Mil,Surveillance,Liaison,Eye In The Sky,Other Air Forces,https://w.wiki/Dstq
+0A4057,7T-WRE,Algerian Air Force,Beechcraft 1900D,B190,Mil,Surveillance,Liaison,Eye In The Sky,Other Air Forces,https://w.wiki/Dstq
+0A4058,7T-WRF,Algerian Air Force,Beechcraft 1900D,B190,Mil,Surveillance,Liaison,Eye In The Sky,Other Air Forces,https://w.wiki/Dstq
+0A405E,7T-WJA,Algerian Air Force,Lockheed C-130J-30 Hercules,C30J,Mil,Cargo,Tactical Airlift,Matsharfeen,Other Air Forces,https://w.wiki/Dstq
+0A405F,7T-WJB,Algerian Air Force,Lockheed C-130J-30 Hercules,C30J,Mil,Cargo,Tactical Airlift,Matsharfeen,Other Air Forces,https://w.wiki/Dstq
+0A4060,7T-WJC,Algerian Air Force,Lockheed C-130J-30 Hercules,C30J,Mil,Cargo,Tactical Airlift,Matsharfeen,Other Air Forces,https://w.wiki/Dstq
+0A4061,7T-WJD,Algerian Air Force,Lockheed C-130J-30 Hercules,C30J,Mil,Cargo,Tactical Airlift,Matsharfeen,Other Air Forces,https://w.wiki/Dstq
+AAECF3,7T-WBH,Algerian Air Force,Beechcraft King Air 90,BE9L,Mil,Surveillance,Liaison,Eye In The Sky,Other Air Forces,https://w.wiki/Dstq


### PR DESCRIPTION
Continuing the series. 

Why Algerian AF? One flew over me, I caught Il-76 7T-WIC on my feeder and noticed the fleet was missing from the list. 
So this adds the Algerian Air Force's missing transports: 
7 Il-76s, 10 C-130H and 3 C-130J Hercules, 2 AW101 Merlins, and their King Air/1900D liaison and surveillance types. 
They transit Central European airspace fairly regularly. 

Hexes from tar1090-db, deduped against the current list, styled to match the existing Algerian entries. 

Thanks!