### PR TITLE
add 19 C-2A Greyhounds

### DIFF
--- a/plane-alert-db.csv
+++ b/plane-alert-db.csv
@@ -16587,3 +16587,22 @@ E90E07,CX-MIA,Uruguay Police,Robinson R44,R44,Pol,Police Squad,Policia,Copper Ch
 E90E0E,CX-MIE,Uruguay Police,Robinson R66,R66,Pol,Police Squad,Policia,Copper Chopper,Police Forces,https://w.wiki/B3LK
 E940FA,FAB-001,Gov of Bolivia,Dassault Falcon 900EX,F900,Gov,Government,Must Be Nice,Free And Fair Elections,Head of State,https://w.wiki/B3LJ
 E940FB,FAB-002,Gov of Bolivia,Dassault Falcon 50,FA50,Gov,Government,Must Be Nice,Free And Fair Elections,Head of State,https://w.wiki/B3LJ
+AE044A,162140,United States Navy,Grumman C-2A Greyhound,C2,Mil,COD,Carrier Onboard Delivery,Flying Troops,Distinctive,https://en.wikipedia.org/wiki/Grumman_C-2_Greyhound
+AE044B,162143,United States Navy,Grumman C-2A Greyhound,C2,Mil,COD,Carrier Onboard Delivery,Flying Troops,Distinctive,https://en.wikipedia.org/wiki/Grumman_C-2_Greyhound
+AE044C,162144,United States Navy,Grumman C-2A Greyhound,C2,Mil,COD,Carrier Onboard Delivery,Flying Troops,Distinctive,https://en.wikipedia.org/wiki/Grumman_C-2_Greyhound
+AE044D,162145,United States Navy,Grumman C-2A Greyhound,C2,Mil,COD,Carrier Onboard Delivery,Flying Troops,Distinctive,https://en.wikipedia.org/wiki/Grumman_C-2_Greyhound
+AE0452,162159,United States Navy,Grumman C-2A Greyhound,C2,Mil,COD,Carrier Onboard Delivery,Flying Troops,Distinctive,https://en.wikipedia.org/wiki/Grumman_C-2_Greyhound
+AE0457,162174,United States Navy,Grumman C-2A Greyhound,C2,Mil,COD,Carrier Onboard Delivery,Flying Troops,Distinctive,https://en.wikipedia.org/wiki/Grumman_C-2_Greyhound
+AE0458,162177,United States Navy,Grumman C-2A Greyhound,C2,Mil,COD,Carrier Onboard Delivery,Flying Troops,Distinctive,https://en.wikipedia.org/wiki/Grumman_C-2_Greyhound
+AE0459,162178,United States Navy,Grumman C-2A Greyhound,C2,Mil,COD,Carrier Onboard Delivery,Flying Troops,Distinctive,https://en.wikipedia.org/wiki/Grumman_C-2_Greyhound
+AE045B,162158,United States Navy,Grumman C-2A Greyhound,C2,Mil,COD,Carrier Onboard Delivery,Flying Troops,Distinctive,https://en.wikipedia.org/wiki/Grumman_C-2_Greyhound
+AE045C,162168,United States Navy,Grumman C-2A Greyhound,C2,Mil,COD,Carrier Onboard Delivery,Flying Troops,Distinctive,https://en.wikipedia.org/wiki/Grumman_C-2_Greyhound
+AE045E,162176,United States Navy,Grumman C-2A Greyhound,C2,Mil,COD,Carrier Onboard Delivery,Flying Troops,Distinctive,https://en.wikipedia.org/wiki/Grumman_C-2_Greyhound
+AE045F,162142,United States Navy,Grumman C-2A Greyhound,C2,Mil,COD,Carrier Onboard Delivery,Flying Troops,Distinctive,https://en.wikipedia.org/wiki/Grumman_C-2_Greyhound
+AE0463,162148,United States Navy,Grumman C-2A Greyhound,C2,Mil,COD,Carrier Onboard Delivery,Flying Troops,Distinctive,https://en.wikipedia.org/wiki/Grumman_C-2_Greyhound
+AE0465,162150,United States Navy,Grumman C-2A Greyhound,C2,Mil,COD,Carrier Onboard Delivery,Flying Troops,Distinctive,https://en.wikipedia.org/wiki/Grumman_C-2_Greyhound
+AE0466,162154,United States Navy,Grumman C-2A Greyhound,C2,Mil,COD,Carrier Onboard Delivery,Flying Troops,Distinctive,https://en.wikipedia.org/wiki/Grumman_C-2_Greyhound
+AE0468,162162,United States Navy,Grumman C-2A Greyhound,C2,Mil,COD,Carrier Onboard Delivery,Flying Troops,Distinctive,https://en.wikipedia.org/wiki/Grumman_C-2_Greyhound
+AE046B,162165,United States Navy,Grumman C-2A Greyhound,C2,Mil,COD,Carrier Onboard Delivery,Flying Troops,Distinctive,https://en.wikipedia.org/wiki/Grumman_C-2_Greyhound
+AE046D,162171,United States Navy,Grumman C-2A Greyhound,C2,Mil,COD,Carrier Onboard Delivery,Flying Troops,Distinctive,https://en.wikipedia.org/wiki/Grumman_C-2_Greyhound
+AE046E,162173,United States Navy,Grumman C-2A Greyhound,C2,Mil,COD,Carrier Onboard Delivery,Flying Troops,Distinctive,https://en.wikipedia.org/wiki/Grumman_C-2_Greyhound


### PR DESCRIPTION
Continuing the series. 

This adds 19 C-2A Greyhounds, the US Navy's carrier onboard delivery fleet. Being replaced by the CMV-22B, so a few may be stale, but I couldn't find anything. 

Hexes from tar1090-db, deduped against the current list, styled like existing entries. 

Thanks!