### PR TITLE
add 16 KC-135 Stratotankers

### DIFF
--- a/plane-alert-db.csv
+++ b/plane-alert-db.csv
@@ -16606,3 +16606,19 @@ E90E07,CX-MIA,Uruguay Police,Robinson R44,R44,Pol,Police Squad,Policia,Copper Ch
 E90E0E,CX-MIE,Uruguay Police,Robinson R66,R66,Pol,Police Squad,Policia,Copper Chopper,Police Forces,https://w.wiki/B3LK
 E940FA,FAB-001,Gov of Bolivia,Dassault Falcon 900EX,F900,Gov,Government,Must Be Nice,Free And Fair Elections,Head of State,https://w.wiki/B3LJ
 E940FB,FAB-002,Gov of Bolivia,Dassault Falcon 50,FA50,Gov,Government,Must Be Nice,Free And Fair Elections,Head of State,https://w.wiki/B3LJ
+3B7774,525,French Air and Space Force,Boeing KC-135R/T Stratotanker,K35R,Mil,Air2Air,Refuel,I Am Old,Other Air Forces,https://en.wikipedia.org/wiki/Boeing_KC-135_Stratotanker
+3B7775,497,French Air and Space Force,Boeing KC-135R/T Stratotanker,K35R,Mil,Air2Air,Refuel,I Am Old,Other Air Forces,https://en.wikipedia.org/wiki/Boeing_KC-135_Stratotanker
+3B7776,740,French Air and Space Force,Boeing KC-135R/T Stratotanker,K35R,Mil,Air2Air,Refuel,I Am Old,Other Air Forces,https://en.wikipedia.org/wiki/Boeing_KC-135_Stratotanker
+3B7777,739,French Air and Space Force,Boeing KC-135R/T Stratotanker,K35R,Mil,Air2Air,Refuel,I Am Old,Other Air Forces,https://en.wikipedia.org/wiki/Boeing_KC-135_Stratotanker
+3B7778,738,French Air and Space Force,Boeing KC-135R/T Stratotanker,K35R,Mil,Air2Air,Refuel,I Am Old,Other Air Forces,https://en.wikipedia.org/wiki/Boeing_KC-135_Stratotanker
+3B7779,737,French Air and Space Force,Boeing KC-135R/T Stratotanker,K35R,Mil,Air2Air,Refuel,I Am Old,Other Air Forces,https://en.wikipedia.org/wiki/Boeing_KC-135_Stratotanker
+3B777A,736,French Air and Space Force,Boeing KC-135R Stratotanker,K35R,Mil,Air2Air,Refuel,I Am Old,Other Air Forces,https://en.wikipedia.org/wiki/Boeing_KC-135_Stratotanker
+3B777F,471,French Air and Space Force,Boeing KC-135R/T Stratotanker,K35R,Mil,Air2Air,Refuel,I Am Old,Other Air Forces,https://en.wikipedia.org/wiki/Boeing_KC-135_Stratotanker
+3B7780,470,French Air and Space Force,Boeing KC-135R/T Stratotanker,K35R,Mil,Air2Air,Refuel,I Am Old,Other Air Forces,https://en.wikipedia.org/wiki/Boeing_KC-135_Stratotanker
+4B8201,58-0110,Turkish Air Force,Boeing KC-135R/T Stratotanker,K35R,Mil,Air2Air,Refuel,I Am Old,Other Air Forces,https://en.wikipedia.org/wiki/Boeing_KC-135_Stratotanker
+4B8202,62-3567,Turkish Air Force,Boeing KC-135R/T Stratotanker,K35R,Mil,Air2Air,Refuel,I Am Old,Other Air Forces,https://en.wikipedia.org/wiki/Boeing_KC-135_Stratotanker
+AE0595,58-0130,USAF,Boeing KC-135R/T Stratotanker,K35R,Mil,Air2Air,Refuel,I Am Old,USAF,https://en.wikipedia.org/wiki/Boeing_KC-135_Stratotanker
+AE0649,57-1494,USAF,Boeing KC-135R/T Stratotanker,K35R,Mil,Air2Air,Refuel,I Am Old,USAF,https://en.wikipedia.org/wiki/Boeing_KC-135_Stratotanker
+AE073C,62-3564,USAF,Boeing KC-135 Stratotanker,K35R,Mil,Air2Air,Refuel,I Am Old,USAF,https://en.wikipedia.org/wiki/Boeing_KC-135_Stratotanker
+AE8372,60-0367,USAF,Boeing KC-135 Stratotanker,K35R,Mil,Air2Air,Refuel,I Am Old,USAF,https://en.wikipedia.org/wiki/Boeing_KC-135_Stratotanker
+AF8504,60-0345,USAF,Boeing KC-135 Stratotanker,K35R,Mil,Air2Air,Refuel,I Am Old,USAF,https://en.wikipedia.org/wiki/Boeing_KC-135_Stratotanker


### PR DESCRIPTION
Continuing the series. 

This adds 16 KC-135 Stratotankers, French Air Force, Turkish Air Force, and a few missing USAF airframes. 

Hexes from tar1090-db, deduped against the current list, styled like existing entries. 

Thanks!