### PR TITLE
Add 21 missing L-39 Albatros

### DIFF
--- a/plane-alert-db.csv
+++ b/plane-alert-db.csv
@@ -16989,3 +16989,24 @@ E90E07,CX-MIA,Uruguay Police,Robinson R44,R44,Pol,Police Squad,Policia,Copper Ch
 E90E0E,CX-MIE,Uruguay Police,Robinson R66,R66,Pol,Police Squad,Policia,Copper Chopper,Police Forces,https://w.wiki/B3LK
 E940FA,FAB-001,Gov of Bolivia,Dassault Falcon 900EX,F900,Gov,Government,Must Be Nice,Free And Fair Elections,Head of State,https://w.wiki/B3LJ
 E940FB,FAB-002,Gov of Bolivia,Dassault Falcon 50,FA50,Gov,Government,Must Be Nice,Free And Fair Elections,Head of State,https://w.wiki/B3LJ
+502C74,YL-KSJ,Baltic Bees display team,Aero L-39C Albatros,L39,Civ,Do A Barrel Roll,Display Team,Aerobatics,Aerobatic Teams,https://en.wikipedia.org/wiki/Baltic_Bees_Jet_Team
+502C83,YL-KSK,Baltic Bees display team,Aero L-39C Albatros,L39,Civ,Do A Barrel Roll,Display Team,Aerobatics,Aerobatic Teams,https://en.wikipedia.org/wiki/Baltic_Bees_Jet_Team
+511035,ES-YLX,Breitling Team,Aero L-39C Albatros,L39,Civ,Do A Barrel Roll,Display Team,Aerobatics,Aerobatic Teams,https://www.breitling.com/gb-en/partnerships/breitling-jet-team
+511041,ES-TLF,Breitling Team,Aero L-39C Albatros,L39,Civ,Do A Barrel Roll,Display Team,Aerobatics,Aerobatic Teams,https://www.breitling.com/gb-en/partnerships/breitling-jet-team
+511045,ES-TLG,Breitling Team,Aero L-39C Albatros,L39,Civ,Do A Barrel Roll,Display Team,Aerobatics,Aerobatic Teams,https://www.breitling.com/gb-en/partnerships/breitling-jet-team
+511048,ES-YLP,Breitling Team,Aero L-39C Albatros,L39,Civ,Do A Barrel Roll,Display Team,Aerobatics,Aerobatic Teams,https://www.breitling.com/gb-en/partnerships/breitling-jet-team
+511056,ES-TLH,Breitling Team,Aero L-39C Albatros,L39,Civ,Do A Barrel Roll,Display Team,Aerobatics,Aerobatic Teams,https://www.breitling.com/gb-en/partnerships/breitling-jet-team
+511083,ES-TLQ,Breitling Team,Aero L-39C Albatros,L39,Civ,Do A Barrel Roll,Display Team,Aerobatics,Aerobatic Teams,https://www.breitling.com/gb-en/partnerships/breitling-jet-team
+511086,ES-RAZ,Breitling Team,Aero L-39C Albatros,L39,Civ,Do A Barrel Roll,Display Team,Aerobatics,Aerobatic Teams,https://www.breitling.com/gb-en/partnerships/breitling-jet-team
+5110A0,ES-TLS,Breitling Team,Aero L-39C Albatros,L39,Civ,Do A Barrel Roll,Display Team,Aerobatics,Aerobatic Teams,https://www.breitling.com/gb-en/partnerships/breitling-jet-team
+5110B6,ES-YLN,Breitling Team,Aero L-39C Albatros,L39,Civ,Do A Barrel Roll,Display Team,Aerobatics,Aerobatic Teams,https://www.breitling.com/gb-en/partnerships/breitling-jet-team
+5110BC,ES-TLU,Breitling Team,Aero L-39C Albatros,L39,Civ,Do A Barrel Roll,Display Team,Aerobatics,Aerobatic Teams,https://www.breitling.com/gb-en/partnerships/breitling-jet-team
+5110D8,ES-TLV,Breitling Team,Aero L-39C Albatros,L39,Civ,Do A Barrel Roll,Display Team,Aerobatics,Aerobatic Teams,https://www.breitling.com/gb-en/partnerships/breitling-jet-team
+5110D9,ES-TGV,Breitling Team,Aero L-39C Albatros,L39,Civ,Do A Barrel Roll,Display Team,Aerobatics,Aerobatic Teams,https://www.breitling.com/gb-en/partnerships/breitling-jet-team
+5110EB,ES-TGU,Breitling Team,Aero L-39C Albatros,L39,Civ,Do A Barrel Roll,Display Team,Aerobatics,Aerobatic Teams,https://www.breitling.com/gb-en/partnerships/breitling-jet-team
+4984B1,2626,Czech Air Force,Aero L-39 Albatros,L39,Mil,Jet Trainer,Do A Barrel Roll,The Air Is Our Sea,Other Air Forces,https://w.wiki/4mdR
+4984B2,0475,Czech Air Force,Aero L-39 Albatros,L39,Mil,Jet Trainer,Do A Barrel Roll,The Air Is Our Sea,Other Air Forces,https://w.wiki/4mdR
+4984B4,0476,Czech Air Force,Aero L-39 Albatros,L39,Mil,Jet Trainer,Do A Barrel Roll,The Air Is Our Sea,Other Air Forces,https://w.wiki/4mdR
+4984EA,0478,Czech Air Force,Aero L-39 Albatros,L39,Mil,Jet Trainer,Do A Barrel Roll,The Air Is Our Sea,Other Air Forces,https://w.wiki/4mdR
+A480B6,N39CV,Private,Aero L-39C Albatros,L39,Civ,Do A Barrel Roll,Jet Trainer,Private Jet Fighter,Joe Cool,https://w.wiki/EQZf
+505FBB,5251,Slovak Air Force,Aero L-39 Albatros,L39,Mil,Jet Trainer,Do A Barrel Roll,Ahoj,Other Air Forces,https://w.wiki/4$vA


### PR DESCRIPTION
Two more from my feeder. One (Italian C-27J MM62224) is already in a batch I've got queued, but this L-39 wasn't in the list: 
N39CV, an N-registered Albatros in a "Dark Star" scheme that flew past me. Registered to a trustee company, so I've listed it as Private, matching the LX-STN entry.

Pulling that thread found more L-39 gaps worth having: 13 more Breitling Team jets and 2 more Baltic Bees (both teams already in the list, these are the rest of their fleets, same hex blocks), plus 4 Czech Air Force and 1 Slovak Air Force airframes on military serials. 21 rows total.

There are ~250 further L-39s missing, but they're overwhelmingly private US warbirds, which didn't look like something the list is trying to cover. Happy to be told otherwise. 

Thanks!