### PR TITLE
Add 66 IL76s and An12s

### DIFF
--- a/plane-alert-db.csv
+++ b/plane-alert-db.csv
@@ -17010,3 +17010,69 @@ E90E07,CX-MIA,Uruguay Police,Robinson R44,R44,Pol,Police Squad,Policia,Copper Ch
 E90E0E,CX-MIE,Uruguay Police,Robinson R66,R66,Pol,Police Squad,Policia,Copper Chopper,Police Forces,https://w.wiki/B3LK
 E940FA,FAB-001,Gov of Bolivia,Dassault Falcon 900EX,F900,Gov,Government,Must Be Nice,Free And Fair Elections,Head of State,https://w.wiki/B3LJ
 E940FB,FAB-002,Gov of Bolivia,Dassault Falcon 50,FA50,Gov,Government,Must Be Nice,Free And Fair Elections,Head of State,https://w.wiki/B3LJ
+791369,21046,Chinese Air Force,Ilyushin IL-76,IL76,Mil,Cargo,Chonky Boy,PLAAF,Other Air Forces,https://w.wiki/4meN
+79193A,30073,Chinese Air Force,Shaanxi Y-8,AN12,Mil,Cargo,Chonky Boy,PLAAF,Other Air Forces,https://w.wiki/4meN
+791CAD,30074,Chinese Air Force,Shaanxi Y-8,AN12,Mil,Cargo,Chonky Boy,PLAAF,Other Air Forces,https://w.wiki/4meN
+79C23C,21041,Chinese Air Force,Ilyushin IL-76,IL76,Mil,Cargo,Chonky Boy,PLAAF,Other Air Forces,https://w.wiki/4meN
+7A2432,82131,Chinese Air Force,Shaanxi Y-8,AN12,Mil,Cargo,Chonky Boy,PLAAF,Other Air Forces,https://w.wiki/4meN
+7A2433,82132,Chinese Air Force,Shaanxi Y-8,AN12,Mil,Cargo,Chonky Boy,PLAAF,Other Air Forces,https://w.wiki/4meN
+7A2434,82133,Chinese Air Force,Shaanxi Y-8,AN12,Mil,Cargo,Chonky Boy,PLAAF,Other Air Forces,https://w.wiki/4meN
+7A4201,20641,Chinese Air Force,Ilyushin IL-76,IL76,Mil,Cargo,Chonky Boy,PLAAF,Other Air Forces,https://w.wiki/4meN
+7A4203,20643,Chinese Air Force,Ilyushin IL-76,IL76,Mil,Cargo,Chonky Boy,PLAAF,Other Air Forces,https://w.wiki/4meN
+7A4207,20550,Chinese Air Force,Ilyushin IL-76,IL76,Mil,Cargo,Chonky Boy,PLAAF,Other Air Forces,https://w.wiki/4meN
+7A420C,21146,Chinese Air Force,Ilyushin IL-76,IL76,Mil,Cargo,Chonky Boy,PLAAF,Other Air Forces,https://w.wiki/4meN
+7A4222,30071,Chinese Air Force,Shaanxi Y-8,AN12,Mil,Cargo,Chonky Boy,PLAAF,Other Air Forces,https://w.wiki/4meN
+7A4230,30072,Chinese Air Force,Shaanxi Y-8,AN12,Mil,Cargo,Chonky Boy,PLAAF,Other Air Forces,https://w.wiki/4meN
+7A4262,30518,Chinese Air Force,Shaanxi Y-8,AN12,Mil,Cargo,Chonky Boy,PLAAF,Other Air Forces,https://w.wiki/4meN
+7A4265,31110,Chinese Air Force,Shaanxi Y-8,AN12,Mil,Cargo,Chonky Boy,PLAAF,Other Air Forces,https://w.wiki/4meN
+7A4298,30720,Chinese Air Force,Shaanxi Y-8,AN12,Mil,Cargo,Chonky Boy,PLAAF,Other Air Forces,https://w.wiki/4meN
+7A429A,53053,Chinese Air Force,Shaanxi Y-8,AN12,Mil,Cargo,Chonky Boy,PLAAF,Other Air Forces,https://w.wiki/4meN
+7A429C,30177,Chinese Air Force,Shaanxi Y-8,AN12,Mil,Cargo,Chonky Boy,PLAAF,Other Air Forces,https://w.wiki/4meN
+7A429E,30174,Chinese Air Force,Shaanxi Y-8,AN12,Mil,Cargo,Chonky Boy,PLAAF,Other Air Forces,https://w.wiki/4meN
+7A429F,30171,Chinese Air Force,Shaanxi Y-8,AN12,Mil,Cargo,Chonky Boy,PLAAF,Other Air Forces,https://w.wiki/4meN
+7A42A3,30079,Chinese Air Force,Shaanxi Y-8,AN12,Mil,Cargo,Chonky Boy,PLAAF,Other Air Forces,https://w.wiki/4meN
+7A42A4,30075,Chinese Air Force,Shaanxi Y-8,AN12,Mil,Cargo,Chonky Boy,PLAAF,Other Air Forces,https://w.wiki/4meN
+7A431A,82011,Chinese Air Force,Shaanxi Y-8,AN12,Mil,Cargo,Chonky Boy,PLAAF,Other Air Forces,https://w.wiki/4meN
+7A431B,82018,Chinese Air Force,Shaanxi Y-8,AN12,Mil,Cargo,Chonky Boy,PLAAF,Other Air Forces,https://w.wiki/4meN
+7A431C,82013,Chinese Air Force,Shaanxi Y-8,AN12,Mil,Cargo,Chonky Boy,PLAAF,Other Air Forces,https://w.wiki/4meN
+7A432D,82015,Chinese Air Force,Shaanxi Y-8,AN12,Mil,Cargo,Chonky Boy,PLAAF,Other Air Forces,https://w.wiki/4meN
+7A43F0,30475,Chinese Air Force,Shaanxi Y-8,AN12,Mil,Cargo,Chonky Boy,PLAAF,Other Air Forces,https://w.wiki/4meN
+7A43F1,30476,Chinese Air Force,Shaanxi Y-8,AN12,Mil,Cargo,Chonky Boy,PLAAF,Other Air Forces,https://w.wiki/4meN
+7B005F,21048,Chinese Air Force,Ilyushin IL-76,IL76,Mil,Cargo,Chonky Boy,PLAAF,Other Air Forces,https://w.wiki/4meN
+7B059F,9231,Chinese Air Force,Shaanxi Y-8,AN12,Mil,Cargo,Chonky Boy,PLAAF,Other Air Forces,https://w.wiki/4meN
+7BCA5D,30515,Chinese Air Force,Shaanxi Y-8,AN12,Mil,Cargo,Chonky Boy,PLAAF,Other Air Forces,https://w.wiki/4meN
+152A26,RF-76326,Russian Air Force,Ilyushin IL-76,IL76,Mil,Cargo,Chonky Boy,Tail Gunner,Other Air Forces,https://w.wiki/Czj9
+152C1C,RF-76828,Russian Air Force,Ilyushin IL-76,IL76,Mil,Cargo,Chonky Boy,Tail Gunner,Other Air Forces,https://w.wiki/Czj9
+15538D,RF-86925,Russian Air Force,Ilyushin IL-76,IL76,Mil,Cargo,Chonky Boy,Tail Gunner,Other Air Forces,https://w.wiki/Czj9
+1B266D,RF-75353,Russian Air Force,Ilyushin IL-76,IL76,Mil,Cargo,Chonky Boy,Tail Gunner,Other Air Forces,https://w.wiki/Czj9
+1B2A23,RF-76323,Russian Air Force,Ilyushin IL-76,IL76,Mil,Cargo,Chonky Boy,Tail Gunner,Other Air Forces,https://w.wiki/Czj9
+1B6C03,RF-76803,Russian Air Force,Ilyushin IL-76,IL76,Mil,Cargo,Chonky Boy,Tail Gunner,Other Air Forces,https://w.wiki/Czj9
+1C333A,RF-78654,Russian Air Force,Ilyushin IL-76,IL76,Mil,Cargo,Chonky Boy,Tail Gunner,Other Air Forces,https://w.wiki/Czj9
+1D2B01,RF-76545,Russian Air Force,Ilyushin IL-76,IL76,Mil,Cargo,Chonky Boy,Tail Gunner,Other Air Forces,https://w.wiki/Czj9
+1D2BE4,RF-76772,Russian Air Force,Ilyushin IL-76,IL76,Mil,Cargo,Chonky Boy,Tail Gunner,Other Air Forces,https://w.wiki/Czj9
+1D333C,RF-78652,Russian Air Force,Ilyushin IL-76,IL76,Mil,Cargo,Chonky Boy,Tail Gunner,Other Air Forces,https://w.wiki/Czj9
+1D333D,RF-78653,Russian Air Force,Ilyushin IL-76,IL76,Mil,Cargo,Chonky Boy,Tail Gunner,Other Air Forces,https://w.wiki/Czj9
+1D3340,RF-78656,Russian Air Force,Ilyushin IL-76,IL76,Mil,Cargo,Chonky Boy,Tail Gunner,Other Air Forces,https://w.wiki/Czj9
+1D3341,RF-78657,Russian Air Force,Ilyushin IL-76,IL76,Mil,Cargo,Chonky Boy,Tail Gunner,Other Air Forces,https://w.wiki/Czj9
+1D3343,RF-78659,Russian Air Force,Ilyushin IL-76,IL76,Mil,Cargo,Chonky Boy,Tail Gunner,Other Air Forces,https://w.wiki/Czj9
+1D3344,RF-78660,Russian Air Force,Ilyushin IL-76,IL76,Mil,Cargo,Chonky Boy,Tail Gunner,Other Air Forces,https://w.wiki/Czj9
+1D3345,RF-78661,Russian Air Force,Ilyushin IL-76,IL76,Mil,Cargo,Chonky Boy,Tail Gunner,Other Air Forces,https://w.wiki/Czj9
+1D3346,RF-78662,Russian Air Force,Ilyushin IL-76,IL76,Mil,Cargo,Chonky Boy,Tail Gunner,Other Air Forces,https://w.wiki/Czj9
+1D3349,RF-78665,Russian Air Force,Ilyushin IL-76,IL76,Mil,Cargo,Chonky Boy,Tail Gunner,Other Air Forces,https://w.wiki/Czj9
+1D334A,RF-78666,Russian Air Force,Ilyushin IL-76,IL76,Mil,Cargo,Chonky Boy,Tail Gunner,Other Air Forces,https://w.wiki/Czj9
+1D33F5,RF-78837,Russian Air Force,Ilyushin IL-76,IL76,Mil,Cargo,Chonky Boy,Tail Gunner,Other Air Forces,https://w.wiki/Czj9
+1F2BCA,RF-76746,Russian Air Force,Ilyushin IL-76,IL76,Mil,Cargo,Chonky Boy,Tail Gunner,Other Air Forces,https://w.wiki/Czj9
+1F333F,RF-78655,Russian Air Force,Ilyushin IL-76,IL76,Mil,Cargo,Chonky Boy,Tail Gunner,Other Air Forces,https://w.wiki/Czj9
+1F3342,RF-78658,Russian Air Force,Ilyushin IL-76,IL76,Mil,Cargo,Chonky Boy,Tail Gunner,Other Air Forces,https://w.wiki/Czj9
+1F3395,RF-78741,Russian Air Force,Ilyushin IL-76,IL76,Mil,Cargo,Chonky Boy,Tail Gunner,Other Air Forces,https://w.wiki/Czj9
+1F7040,RF-94272,Russian Air Force,Ilyushin IL-76,IL76,Mil,Cargo,Chonky Boy,Tail Gunner,Other Air Forces,https://w.wiki/Czj9
+50807F,76658,Ukraine Air Force,Ilyushin IL-76,IL76,Mil,Cargo,Chonky Boy,Tail Gunner,Ukraine,https://en.wikipedia.org/wiki/Ukrainian_Air_Force
+508131,76413,Ukraine Air Force,Ilyushin IL-76,IL76,Mil,Cargo,Chonky Boy,Tail Gunner,Ukraine,https://en.wikipedia.org/wiki/Ukrainian_Air_Force
+50FF3A,76699,Ukraine Air Force,Ilyushin IL-76,IL76,Mil,Cargo,Chonky Boy,Tail Gunner,Ukraine,https://en.wikipedia.org/wiki/Ukrainian_Air_Force
+50FF3B,76683,Ukraine Air Force,Ilyushin IL-76,IL76,Mil,Cargo,Chonky Boy,Tail Gunner,Ukraine,https://en.wikipedia.org/wiki/Ukrainian_Air_Force
+50FFC0,76697,Ukraine Air Force,Ilyushin IL-76,IL76,Mil,Cargo,Chonky Boy,Tail Gunner,Ukraine,https://en.wikipedia.org/wiki/Ukrainian_Air_Force
+50FFE2,76655,Ukraine Air Force,Ilyushin IL-76,IL76,Mil,Cargo,Chonky Boy,Tail Gunner,Ukraine,https://en.wikipedia.org/wiki/Ukrainian_Air_Force
+50FFEE,76661,Ukraine Air Force,Ilyushin IL-76,IL76,Mil,Cargo,Chonky Boy,Tail Gunner,Ukraine,https://en.wikipedia.org/wiki/Ukrainian_Air_Force
+0D8212,2803,Venezuelan Air Force,Shaanxi Y-8F-200W,AN12,Mil,Cargo,Bolivarian Military Aviation,The Paladin Of The Sovereign Space,Other Air Forces,https://w.wiki/4n52
+0D8216,2509,Venezuelan Air Force,Shaanxi Y-8F-200W,AN12,Mil,Cargo,Bolivarian Military Aviation,The Paladin Of The Sovereign Space,Other Air Forces,https://w.wiki/4n52
+0D8218,1192,Venezuelan Air Force,Shaanxi Y-8F-200W,AN12,Mil,Cargo,Bolivarian Military Aviation,The Paladin Of The Sovereign Space,Other Air Forces,https://w.wiki/4n52


### PR DESCRIPTION
@dziban303 mentioned Ukrainian An-12s in #849 , so I went looking. 

215 An-12s/Il-76s are missing from the list, but only 66 could I attribute confidently, so that's what this is: 
31 Chinese AF (79xx/7Axx blocks, numeric serials, alongside the ones already listed, the An-12-coded ones are Y-8s), 25 Russian AF (RF- state registry), 7 Ukraine AF (50FFxx, next to 50FF39 already in the list), 3 Venezuelan AF.

I deliberately left out ~150: the UR-/EX-/EW-/UP-/4K- civil cargo fleets have almost no owner data in tar1090-db and change hands constantly, and I dropped two groups where the source data contradicted itself. Rather not guess. Happy to revisit if you have better attribution for the cargo outfits.