### PR TITLE
Add 4 Fubar Aviation MiGs (only airworthy MiG-15bis and MiG-17 in Europe)

### DIFF
--- a/plane-alert-db.csv
+++ b/plane-alert-db.csv
@@ -17076,3 +17076,7 @@ E90E07,CX-MIA,Uruguay Police,Robinson R44,R44,Pol,Police Squad,Policia,Copper Ch
 E90E0E,CX-MIE,Uruguay Police,Robinson R66,R66,Pol,Police Squad,Policia,Copper Chopper,Police Forces,https://w.wiki/B3LK
 E940FA,FAB-001,Gov of Bolivia,Dassault Falcon 900EX,F900,Gov,Government,Must Be Nice,Free And Fair Elections,Head of State,https://w.wiki/B3LJ
 E940FB,FAB-002,Gov of Bolivia,Dassault Falcon 50,FA50,Gov,Government,Must Be Nice,Free And Fair Elections,Head of State,https://w.wiki/B3LJ
+48B106,SP-MIG,Fubar Aviation,WSK Lim-2 (MiG-15bis),MG15,Civ,Mig,602,Made in Poland,Historic,https://en.wikipedia.org/wiki/Mikoyan-Gurevich_MiG-15
+48CE48,SP-UTI,Fubar Aviation,WSK SB Lim-2 (MiG-15UTI),MG15,Civ,Mig,006,Made in Poland,Historic,https://en.wikipedia.org/wiki/Mikoyan-Gurevich_MiG-15
+48DDB5,SP-YNZ,Fubar Aviation,WSK SB Lim-2 (MiG-15UTI),MG15,Civ,Mig,006,Made in Poland,Historic,https://en.wikipedia.org/wiki/Mikoyan-Gurevich_MiG-15
+48E6D0,SP-MIL,Fubar Aviation,WSK Lim-5 (MiG-17F),MG17,Civ,Mig,1211,Made in Poland,Historic,https://en.wikipedia.org/wiki/Mikoyan-Gurevich_MiG-17


### PR DESCRIPTION
A local one, Fubar Aviation operate three Polish-built MiGs from Olsztyn-Mazury (they moved there from Warsaw-Modlin in June), and none are in the list. I caught SP-MIG overhead, which prompted this.

**SP-MIG** (48B106): Lim-2 / MiG-15bis, tactical 602, currently the only airworthy MiG-15bis in Europe

**SP-UTI** (48CE48): SB Lim-2 / MiG-15UTI, tactical 006

**SP-YNZ** (48DDB5): same airframe as SP-UTI, previous registration. Included per the same reasoning as the Turkish E-7T hexes in #827, happy to drop it if you'd rather

**SP-MIL** (48E6D0): Lim-5 / MiG-17F, c/n 1C1211, the only airworthy MiG-17 in Europe (flew again in April after a 2.5-year restoration)

One data note: tar1090-db still has 48B106 as a SOCATA TB-9 Tampico, the SP-MIG registration was reassigned to the Lim-2 and the hex went with it, so the type may render wrong from that source. Confirmed the hex from my own feeder and airplanes.live.

They've also just acquired MiG-21UM 9311, due to become the only flying MiG-21 in Europe, no civil registration announced yet, so I'll add it when there's something to add. Thanks!