### PR TITLE
Add SP-MXS (48B2D1)

### DIFF
--- a/plane-alert-db.csv
+++ b/plane-alert-db.csv
@@ -17080,3 +17080,4 @@ E90E07,CX-MIA,Uruguay Police,Robinson R44,R44,Pol,Police Squad,Policia,Copper Ch
 E90E0E,CX-MIE,Uruguay Police,Robinson R66,R66,Pol,Police Squad,Policia,Copper Chopper,Police Forces,https://w.wiki/B3LK
 E940FA,FAB-001,Gov of Bolivia,Dassault Falcon 900EX,F900,Gov,Government,Must Be Nice,Free And Fair Elections,Head of State,https://w.wiki/B3LJ
 E940FB,FAB-002,Gov of Bolivia,Dassault Falcon 50,FA50,Gov,Government,Must Be Nice,Free And Fair Elections,Head of State,https://w.wiki/B3LJ
+48B2D1,SP-MXS,Polish Medical Air Service,Learjet 75 Liberty,LJ75,Civ,Air Ambo,Medical Evac,Saving Lives,Flying Doctors,https://www.lpr.com.pl/en/home-page/


### PR DESCRIPTION
Caught SP-MXS overhead (LPR41) and it wasn't in the list. Its twin SP-MXR is already there, so this is just the other half of LPR's Learjet 75 Liberty pair, both delivered in December 2021 for inter-hospital transport, based at Warsaw Chopin.

Small inconsistency worth flagging: SP-MXR's row uses operator "Polish Medical Air Rescue", while the other 31 LPR entries use "Polish Medical Air Service". I've used "Polish Medical Air Service" here to match the majority. Happy to send a one-line fix normalizing SP-MXR too if you want them consistent.

Thanks!