### PR TITLE
Add 99 missing Turkish Bayraktars

### DIFF
--- a/plane-alert-db.csv
+++ b/plane-alert-db.csv
@@ -17080,3 +17080,102 @@ E90E07,CX-MIA,Uruguay Police,Robinson R44,R44,Pol,Police Squad,Policia,Copper Ch
 E90E0E,CX-MIE,Uruguay Police,Robinson R66,R66,Pol,Police Squad,Policia,Copper Chopper,Police Forces,https://w.wiki/B3LK
 E940FA,FAB-001,Gov of Bolivia,Dassault Falcon 900EX,F900,Gov,Government,Must Be Nice,Free And Fair Elections,Head of State,https://w.wiki/B3LJ
 E940FB,FAB-002,Gov of Bolivia,Dassault Falcon 50,FA50,Gov,Government,Must Be Nice,Free And Fair Elections,Head of State,https://w.wiki/B3LJ
+4B8357,TC-T510,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8358,TC-S6,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8359,TC-S8,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B835A,TC-S11,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B835B,TC-S12,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B835C,TC-S26,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B835D,TC-S27,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B835E,TC-S28,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8360,TC-S31,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8361,TC-S38,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8362,TC-S39,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8363,TC-S48,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8364,TC-T1,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8365,TC-T2,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8368,TC-T3,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8369,TC-T12,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B836A,TC-T13,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B836B,TC-T14,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B836C,TC-T37,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B836D,TC-T39,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B836E,TC-T62,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B836F,TC-T63,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8370,TC-T65,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8371,TC-T86,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8372,TC-T87,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8373,TC-T97,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8374,TC-T98,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8375,TC-T100,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8376,TC-T101,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8377,TC-T102,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8378,TC-T174,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8379,TC-T233,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B837A,TC-T234,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B837B,TC-T235,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B837C,TC-T236,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B837D,TC-T237,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B837E,TC-T238,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8382,TC-S014,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8383,TC-S015,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8385,TC-S041,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B838E,TC-T114,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B838F,TC-T153,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8390,TC-T154,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B839D,TC-T314,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B839E,TC-T315,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B839F,TC-T316,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B83A0,TC-T317,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B83A1,TC-T318,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B83A2,TC-T319,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B83A3,TC-T320,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B83AD,TC-T375,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B83AF,TC-T377,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B83B0,TC-T378,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B83B1,TC-T379,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B83D5,TC-T499,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B83D6,TC-T500,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8408,TC-T590,Turkish Air Force,Baykar Bayraktar TB2,BTB2,Mil,UAV,Skynet,Uphold The Public Trust,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B801A,TC-J60,Turkish National Police,Baykar Bayraktar TB2,BTB2,Pol,UAV,Police Squad,Skynet,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B832A,TC-J4,Turkish National Police,Baykar Bayraktar TB2,BTB2,Pol,UAV,Police Squad,Skynet,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B832B,TC-J5,Turkish National Police,Baykar Bayraktar TB2,BTB2,Pol,UAV,Police Squad,Skynet,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B832C,TC-J6,Turkish National Police,Baykar Bayraktar TB2,BTB2,Pol,UAV,Police Squad,Skynet,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B832D,TC-J7,Turkish National Police,Baykar Bayraktar TB2,BTB2,Pol,UAV,Police Squad,Skynet,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B832E,TC-J8,Turkish National Police,Baykar Bayraktar TB2,BTB2,Pol,UAV,Police Squad,Skynet,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B832F,TC-J9,Turkish National Police,Baykar Bayraktar TB2,BTB2,Pol,UAV,Police Squad,Skynet,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8330,TC-J10,Turkish National Police,Baykar Bayraktar TB2,BTB2,Pol,UAV,Police Squad,Skynet,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8331,TC-J11,Turkish National Police,Baykar Bayraktar TB2,BTB2,Pol,UAV,Police Squad,Skynet,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8332,TC-J12,Turkish National Police,Baykar Bayraktar TB2,BTB2,Pol,UAV,Police Squad,Skynet,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8333,TC-J13,Turkish National Police,Baykar Bayraktar TB2,BTB2,Pol,UAV,Police Squad,Skynet,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8334,TC-J14,Turkish National Police,Baykar Bayraktar TB2,BTB2,Pol,UAV,Police Squad,Skynet,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8335,TC-J15,Turkish National Police,Baykar Bayraktar TB2,BTB2,Pol,UAV,Police Squad,Skynet,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8336,TC-J16,Turkish National Police,Baykar Bayraktar TB2,BTB2,Pol,UAV,Police Squad,Skynet,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8337,TC-J17,Turkish National Police,Baykar Bayraktar TB2,BTB2,Pol,UAV,Police Squad,Skynet,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8338,TC-J18,Turkish National Police,Baykar Bayraktar TB2,BTB2,Pol,UAV,Police Squad,Skynet,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8339,TC-J19,Turkish National Police,Baykar Bayraktar TB2,BTB2,Pol,UAV,Police Squad,Skynet,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B833A,TC-J20,Turkish National Police,Baykar Bayraktar TB2,BTB2,Pol,UAV,Police Squad,Skynet,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B833B,TC-J21,Turkish National Police,Baykar Bayraktar TB2,BTB2,Pol,UAV,Police Squad,Skynet,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B833C,TC-J22,Turkish National Police,Baykar Bayraktar TB2,BTB2,Pol,UAV,Police Squad,Skynet,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B833D,TC-J23,Turkish National Police,Baykar Bayraktar TB2,BTB2,Pol,UAV,Police Squad,Skynet,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B833E,TC-J24,Turkish National Police,Baykar Bayraktar TB2,BTB2,Pol,UAV,Police Squad,Skynet,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B833F,TC-J25,Turkish National Police,Baykar Bayraktar TB2,BTB2,Pol,UAV,Police Squad,Skynet,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8340,TC-J26,Turkish National Police,Baykar Bayraktar TB2,BTB2,Pol,UAV,Police Squad,Skynet,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8345,TC-J33,Turkish National Police,Baykar Bayraktar TB2,BTB2,Pol,UAV,Police Squad,Skynet,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8346,TC-J34,Turkish National Police,Baykar Bayraktar TB2,BTB2,Pol,UAV,Police Squad,Skynet,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8347,TC-J35,Turkish National Police,Baykar Bayraktar TB2,BTB2,Pol,UAV,Police Squad,Skynet,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8349,TC-J36,Turkish National Police,Baykar Bayraktar TB2,BTB2,Pol,UAV,Police Squad,Skynet,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B834A,TC-J37,Turkish National Police,Baykar Bayraktar TB2,BTB2,Pol,UAV,Police Squad,Skynet,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B834B,TC-J38,Turkish National Police,Baykar Bayraktar TB2,BTB2,Pol,UAV,Police Squad,Skynet,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8354,TC-J39,Turkish National Police,Baykar Bayraktar TB2,BTB2,Pol,UAV,Police Squad,Skynet,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8355,TC-J40,Turkish National Police,Baykar Bayraktar TB2,BTB2,Pol,UAV,Police Squad,Skynet,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8392,TC-J1,Turkish National Police,Baykar Bayraktar TB2,BTB2,Pol,UAV,Police Squad,Skynet,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8393,TC-J2,Turkish National Police,Baykar Bayraktar TB2,BTB2,Pol,UAV,Police Squad,Skynet,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8394,TC-J3,Turkish National Police,Baykar Bayraktar TB2,BTB2,Pol,UAV,Police Squad,Skynet,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8395,TC-J4,Turkish National Police,Baykar Bayraktar TB2,BTB2,Pol,UAV,Police Squad,Skynet,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8396,TC-J5,Turkish National Police,Baykar Bayraktar TB2,BTB2,Pol,UAV,Police Squad,Skynet,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8397,TC-J6,Turkish National Police,Baykar Bayraktar TB2,BTB2,Pol,UAV,Police Squad,Skynet,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8398,TC-J7,Turkish National Police,Baykar Bayraktar TB2,BTB2,Pol,UAV,Police Squad,Skynet,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B8399,TC-J8,Turkish National Police,Baykar Bayraktar TB2,BTB2,Pol,UAV,Police Squad,Skynet,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B839A,TC-J9,Turkish National Police,Baykar Bayraktar TB2,BTB2,Pol,UAV,Police Squad,Skynet,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2
+4B839B,TC-J10,Turkish National Police,Baykar Bayraktar TB2,BTB2,Pol,UAV,Police Squad,Skynet,UAV,https://en.wikipedia.org/wiki/Baykar_Bayraktar_TB2


### PR DESCRIPTION
An entire type is missing from the list: there are 123 Turkish Bayraktar TB-2s in tar1090-db and none in the database.

This adds 99 where I could verify the operator against FR24's own attribution: 57 Turkish Air Force (the TC-T and TC-S series) and 42 Turkish National Police (TC-J series). Styled like the other UAV entries.

Left out 24 whose service I couldn't confirm, the OR-, EM- and TCSG- prefixes. TCSG is presumably Sahil Güvenlik and EM presumably Emniyet, but the list already separates Turkish Police, Turkish National Police and Turkish Coast Guard, so I'd rather not guess which bucket they belong in. Happy to add them if you know.

Worth noting these are MLAT-only, they broadcast Mode S without ADS-B position, so they only appear where feeder density is high enough to multilaterate.