### PR TITLE
Add 5 Polish survey and training aircraft

### DIFF
--- a/plane-alert-db.csv
+++ b/plane-alert-db.csv
@@ -17080,3 +17080,8 @@ E90E07,CX-MIA,Uruguay Police,Robinson R44,R44,Pol,Police Squad,Policia,Copper Ch
 E90E0E,CX-MIE,Uruguay Police,Robinson R66,R66,Pol,Police Squad,Policia,Copper Chopper,Police Forces,https://w.wiki/B3LK
 E940FA,FAB-001,Gov of Bolivia,Dassault Falcon 900EX,F900,Gov,Government,Must Be Nice,Free And Fair Elections,Head of State,https://w.wiki/B3LJ
 E940FB,FAB-002,Gov of Bolivia,Dassault Falcon 50,FA50,Gov,Government,Must Be Nice,Free And Fair Elections,Head of State,https://w.wiki/B3LJ
+48A231,SP-ISS,Opegieka,Beech King Air C90A,BE9L,Civ,Aerial Survey,Measuring Stick,Trundle Wheel,Ptolemy would be proud,https://opegieka.pl
+48B9E4,SP-OPE,Opegieka,Tecnam P.2006T SMP,P06T,Civ,Aerial Survey,Measuring Stick,Trundle Wheel,Ptolemy would be proud,https://opegieka.pl
+48B9E9,SP-OPK,Opegieka,Diamond Aircraft DA62,DA62,Civ,Aerial Survey,Measuring Stick,Trundle Wheel,Ptolemy would be proud,https://opegieka.pl
+48C672,SP-SUT,Silesian University of Technology,Tecnam P.2006T Mk II,P06T,Civ,Flight Training,Multi Engine,Acronym,Vanity Plate,https://www.polsl.pl/rt/en/
+48E9DF,SP-OPA,Opegieka,Diamond Aircraft DA62,DA62,Civ,Aerial Survey,Measuring Stick,Trundle Wheel,Ptolemy would be proud,https://opegieka.pl


### PR DESCRIPTION
Two Polish civil operators, both flying regularly over my feeder near Warsaw.

Opegieka (Elbląg photogrammetry company, already in the list with SP-GEO and SP-OPG), four more aircraft: 
SP-ISS (Beech King Air C90A), SP-OPE (Tecnam P.2006T SMP, carries their CityMapper 2S sensor for simultaneous vertical/oblique/LiDAR capture), and Diamond DA62s SP-OPK and SP-OPA. Fleet confirmed against the Polish CAA's published SPO operator register rather than inferred, which is how I caught SP-ISS, it sits outside the SP-OP* registration block.

SP-SUT: Tecnam P.2006T Mk II of the Silesian University of Technology's academic flight training centre at Gliwice. Filed under Vanity Plate since the registration spells the operator's initials.

One data note, and it's the fourth of these I've hit: 
tar1090-db has 48C672/SP-SUT as a PZL-Świdnik W-3 Sokol, with type descriptor H2T, so it renders as a twin-turbine helicopter rather than a light fixed-wing twin. The marks previously belonged to a Heliseco W-3AS (s/n 310307, last photographed as SP-SUT in 2009) and were later reassigned to the Tecnam (s/n 359, photographed 2023). Confirmed the hex from airplanes.live and my own feeder.

Same pattern as SP-MIG (still listed there as a SOCATA TB-9) and the PANSA Turbolets SP-TPA/SP-TPB (left the fleet 2023 and 2016, still listed). Reassigned Polish registrations look like a systematic blind spot in tar1090-db, might be worth raising upstream if you have a line to them.

Thanks!