### PR TITLE
Add 12 missing embraers c390 milenium

### DIFF
--- a/plane-alert-db.csv
+++ b/plane-alert-db.csv
@@ -17185,3 +17185,15 @@ E90E07,CX-MIA,Uruguay Police,Robinson R44,R44,Pol,Police Squad,Policia,Copper Ch
 E90E0E,CX-MIE,Uruguay Police,Robinson R66,R66,Pol,Police Squad,Policia,Copper Chopper,Police Forces,https://w.wiki/B3LK
 E940FA,FAB-001,Gov of Bolivia,Dassault Falcon 900EX,F900,Gov,Government,Must Be Nice,Free And Fair Elections,Head of State,https://w.wiki/B3LJ
 E940FB,FAB-002,Gov of Bolivia,Dassault Falcon 50,FA50,Gov,Government,Must Be Nice,Free And Fair Elections,Head of State,https://w.wiki/B3LJ
+E494A2,FAB2854,Brazilian Air Force,Embraer C-390 Millennium,E390,Mil,Cargo,Tactical Airlift,FAB,Other Air Forces,https://en.wikipedia.org/wiki/Brazilian_Air_Force
+E494A4,FAB2856,Brazilian Air Force,Embraer C-390 Millennium,E390,Mil,Cargo,Tactical Airlift,FAB,Other Air Forces,https://en.wikipedia.org/wiki/Brazilian_Air_Force
+E494A5,FAB2857,Brazilian Air Force,Embraer C-390 Millennium,E390,Mil,Cargo,Tactical Airlift,FAB,Other Air Forces,https://en.wikipedia.org/wiki/Brazilian_Air_Force
+E494A6,FAB2858,Brazilian Air Force,Embraer C-390 Millennium,E390,Mil,Cargo,Tactical Airlift,FAB,Other Air Forces,https://en.wikipedia.org/wiki/Brazilian_Air_Force
+E494A7,FAB2859,Brazilian Air Force,Embraer C-390 Millennium,E390,Mil,Cargo,Tactical Airlift,FAB,Other Air Forces,https://en.wikipedia.org/wiki/Brazilian_Air_Force
+4984F0,0520,Czech Air Force,Embraer C-390 Millennium,E390,Mil,Cargo,Tactical Airlift,The Air Is Our Sea,Other Air Forces,https://w.wiki/4mdR
+477F85,610,Hungarian Air Force,Embraer C-390 Millennium,E390,Mil,Cargo,Tactical Airlift,Magyar Legiero,Other Air Forces,https://en.wikipedia.org/wiki/Hungarian_Air_Force
+477F86,611,Hungarian Air Force,Embraer C-390 Millennium,E390,Mil,Cargo,Tactical Airlift,Magyar Legiero,Other Air Forces,https://en.wikipedia.org/wiki/Hungarian_Air_Force
+497CDC,26901,Portuguese Air Force,Embraer C-390 Millennium,E390,Mil,Cargo,Tactical Airlift,Chappy,Other Air Forces,https://www.emfa.pt/
+497CDD,26902,Portuguese Air Force,Embraer C-390 Millennium,E390,Mil,Cargo,Tactical Airlift,Chappy,Other Air Forces,https://www.emfa.pt/
+497CDE,26903,Portuguese Air Force,Embraer C-390 Millennium,E390,Mil,Cargo,Tactical Airlift,Chappy,Other Air Forces,https://www.emfa.pt/
+497CDF,26904,Portuguese Air Force,Embraer C-390 Millennium,E390,Mil,Cargo,Tactical Airlift,Chappy,Other Air Forces,https://www.emfa.pt/


### PR DESCRIPTION
Another type entirely absent from the list: 
there are no C-390 Millenniums in the database at all. Caught Hungarian 611 over Warsaw, which turned this up.

12 aircraft:
5 Brazilian Air Force, 4 Portuguese, 2 Hungarian (610, 611), and the Czech Air Force's 0520, delivered to Prague-Kbely on 16 July. Styled after each operator's existing rows.

Left out three PT- registered Embraer company demonstrators, the list has no Embraer operator, so that'd be a new one. Happy to add if you'd like them.

Two notes: I've used the family name "C-390 Millennium" throughout even though several are KC-390 tanker variants, since tar1090-db doesn't distinguish them, easy to split if you'd prefer. And E390 (C-390 Millennium) is easily confused with E314 (EMB-314 Super Tucano), which the list already has five of.